### PR TITLE
updates to install quick executables in AMBER installation directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ checkfolders:
 #  ! Installation targets                                                !
 #  !---------------------------------------------------------------------!
 
-.PHONY: noinstall install serialinstall mpiinstall cudainstall cudampiinstall
+.PHONY: noinstall install serialinstall mpiinstall cudainstall cudampiinstall aminstall
 
 install: $(INSTALLTYPES)
 	@echo  "Installation sucessful."
@@ -99,6 +99,12 @@ cudampiinstall:
 	@cp -f $(exefolder)/quick.cuda.mpi $(installfolder)/bin
 	@cp -f $(buildfolder)/include/cudampi/* $(installfolder)/include/cudampi
 	@cp -f $(buildfolder)/lib/cudampi/* $(installfolder)/lib/cudampi
+
+aminstall:
+	@if [ "$(AMINSTALL)" = 'true' ]; then cp -f $(exefolder)/quick* $(amfolder)/bin; \
+	echo "Successfully installed QUICK executables in $(amfolder)/bin folder."; \
+	else echo  "Error: You must set the path to AMBER home directory before running 'make install'."; fi
+
 
 #  !---------------------------------------------------------------------!
 #  ! Installation targets                                                !
@@ -163,7 +169,7 @@ makeinclean:
 #  ! Uninstall targets                                                   !
 #  !---------------------------------------------------------------------!
 
-.PHONY: nouninstall uninstall serialuninstall mpiuninstall cudauninstall cudampiuninstall 
+.PHONY: nouninstall uninstall serialuninstall mpiuninstall cudauninstall cudampiuninstall amuninstall 
 
 uninstall: $(UNINSTALLTYPES)
 	@if [ "$(TESTTYPE)" = 'installtest' ]; then rm -rf $(installfolder)/basis; \
@@ -194,3 +200,9 @@ cudampiuninstall:
 	@-rm -rf $(installfolder)/include/cudampi
 	@-rm -rf $(installfolder)/lib/cudampi
 
+amuninstall:
+	@-rm -f $(amfolder)/bin/quick
+	@-rm -f $(amfolder)/bin/quick.mpi
+	@-rm -f $(amfolder)/bin/quick.cuda
+	@-rm -f $(amfolder)/bin/quick.cuda.mpi
+	@echo  "Successfully uninstalled QUICK executables in $(amfolder)/bin folder."

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ cudampiinstall:
 aminstall:
 	@if [ "$(AMINSTALL)" = 'true' ]; then cp -f $(exefolder)/quick* $(amfolder)/bin; \
 	echo "Successfully installed QUICK executables in $(amfolder)/bin folder."; \
-	else echo  "Error: You must set the path to AMBER home directory before running 'make install'."; fi
+	else echo  "Error: You must set the path to AMBER home directory before running 'make aminstall'."; fi
 
 
 #  !---------------------------------------------------------------------!

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ lab at Michigan State University.
 Features
 --------
 * Single point Hartree-Fock calculations (closed shell only) 
-* Density functional theory calculations (LGA, GGA and Hybrid-GGA functionals available, closed shell only).
+* Density functional theory calculations (LDA, GGA and Hybrid-GGA functionals available, closed shell only).
 * Gradient and geometry optimization calculations (LBFGS solver available)
 * Mulliken charge analysis
 

--- a/configure
+++ b/configure
@@ -56,6 +56,8 @@ echo  "
       --nof          Disables the compilation of time consuming f functions 
                      in the ERI code of cuda version. Not recommended for 
                      production.
+      --amprefix <dir>
+                     Path to AMBER home directory
                                                                             
   Supported compilers are: gnu, intel                                       
                                                                             
@@ -429,6 +431,10 @@ ncores=''
 # track if f functions should not be compiled in cuda version
 nof='no'
 
+# amber related variables
+useamprefix='false'
+amprefix=''
+
 #  !---------------------------------------------------------------------!
 #  ! Check user input                                                    !
 #  !---------------------------------------------------------------------!
@@ -446,6 +452,7 @@ while [ $# -gt 0 ]; do
     --arch)        shift; cuda_arch="$cuda_arch $1"; uspec_arch='true';;
     --ncores)      shift; ncores=$1; uspec_ncores='yes';;
     --prefix)      shift; quick_prefix=${1%/}; useprefix='true';;
+    --amprefix)    shift; amprefix=${1%/}; useamprefix='true';;
     gnu)           compiler='gnu';;
     intel)         compiler='intel';;
     -h| -H| -help| --help) print_help;;
@@ -545,6 +552,23 @@ else
   uninstalltypes='nouninstall'
 
 fi
+
+# check amber prefix 
+if [ "$useamprefix" = "true" ]; then
+
+  # do this trick to get absolute path
+  cd "$amprefix"
+  amprefix=`pwd`
+  cd "$QUICK_HOME"
+
+  if [ ! -d "$amprefix/bin" ]; then
+    echo  "Error: $amprefix/bin not found."
+    exit 1
+  else
+    echo "QUICK executables will be installed in $amprefix/bin folder."
+  fi
+fi
+
 
 #  !---------------------------------------------------------------------!
 #  ! Create essential build directories                                  !
@@ -963,6 +987,7 @@ CLEANTYPES=$cleantypes
 
 INSTALLTYPES=$installtypes
 UNINSTALLTYPES=$uninstalltypes
+AMINSTALL=$useamprefix
 
 TESTTYPE=$testtype
 
@@ -975,6 +1000,7 @@ exefolder=$QUICK_HOME/bin
 buildfolder=$QUICK_HOME/build
 toolsfolder=$QUICK_HOME/tools
 installfolder=$quick_prefix
+amfolder=$amprefix
 
 # source directories
 subfolder=$QUICK_HOME/src/subs
@@ -997,7 +1023,13 @@ echo ""
 
 echo  "Next steps:"
 echo  "          Run 'make' to build QUICK."
+
 if [ "$testtype" = 'installtest' ]; then 
-  echo  "          Run 'make install' to install executable/s, libraries and header files into $quick_prefix."
+  echo  "          Run 'make install' to install executable/s, libraries and header files in $quick_prefix."
 fi
+
 echo  "          Run 'make test' to verify the executables."
+
+if [ "$useamprefix" = "true" ]; then
+echo  "          Run 'make aminstall' to install QUICK executables in $amprefix."
+fi


### PR DESCRIPTION
These updates enable installing and uninstalling quick executables in $AMBER_HOME/bin. To install QUICK from AMBER scripts, (assuming serial installation) do the following.
`./configure --serial --amprefix $AMBER_HOME gnu`
`make`
`make aminstall`
To uninstall, simply run `make amuninstall`