### PR TITLE
Updates for AMBER compatible install and uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,24 +73,24 @@ install: $(INSTALLTYPES)
 	@echo  "Please add the following into your .bash_profile or .bashrc file."
 	@echo  "      export QUICK_BASIS=$(installfolder)/basis"
 
-noinstall:
+noinstall: all
 	@echo  "Please find QUICK executables in $(exefolder)."
 
-serialinstall:
+serialinstall: serial
 	@if [ -x $(exefolder)/quick ]; then cp -f $(exefolder)/quick $(installfolder)/bin; \
 	else echo  "Error: Executable not found. You must run 'make' before running 'make install'."; \
 	exit 1; fi
 	@cp -f $(buildfolder)/include/serial/* $(installfolder)/include/serial
 	@cp -f $(buildfolder)/lib/serial/* $(installfolder)/lib/serial
 
-mpiinstall:
+mpiinstall: mpi
 	@if [ -x $(exefolder)/quick.MPI ]; then cp -f $(exefolder)/quick.MPI $(installfolder)/bin; \
         else echo  "Error: Executable not found. You must run 'make' before running 'make install'."; \
         exit 1; fi
 	@cp -f $(buildfolder)/include/mpi/* $(installfolder)/include/mpi
 	@cp -f $(buildfolder)/lib/mpi/* $(installfolder)/lib/mpi
 
-cudainstall:
+cudainstall: cuda
 	@if [ -x $(exefolder)/quick.cuda ]; then cp -f $(exefolder)/quick.cuda $(installfolder)/bin; \
         else echo  "Error: Executable not found. You must run 'make' before running 'make install'."; \
         exit 1; fi
@@ -98,7 +98,7 @@ cudainstall:
 	@cp -f $(buildfolder)/include/cuda/* $(installfolder)/include/cuda
 	@cp -f $(buildfolder)/lib/cuda/* $(installfolder)/lib/cuda
 
-cudampiinstall:
+cudampiinstall: cudampi
 	@if [ -x $(exefolder)/quick.cuda.MPI ]; then cp -f $(exefolder)/quick.cuda.MPI $(installfolder)/bin; \
         else echo  "Error: Executable not found. You must run 'make' before running 'make install'."; \
         exit 1; fi
@@ -106,7 +106,7 @@ cudampiinstall:
 	@cp -f $(buildfolder)/include/cudampi/* $(installfolder)/include/cudampi
 	@cp -f $(buildfolder)/lib/cudampi/* $(installfolder)/lib/cudampi
 
-aminstall:
+aminstall: all
 	@if [ -d $(installfolder)/lib ]; then \
 	if [ -e $(buildfolder)/lib/serial/libquick.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/serial/libquick.$(libsuffix) $(installfolder)/lib/libquick.$(libsuffix); \
 	ln -s -f $(buildfolder)/lib/serial/libxc.$(libsuffix) $(installfolder)/lib/libxc.$(libsuffix); fi; \

--- a/Makefile
+++ b/Makefile
@@ -107,20 +107,20 @@ cudampiinstall:
 	@cp -f $(buildfolder)/lib/cudampi/* $(installfolder)/lib/cudampi
 
 aminstall:
-	@if [ -d $(amfolder)/lib ]; then \
-	if [ -e $(buildfolder)/lib/serial/libquick.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/serial/libquick.$(libsuffix) $(amfolder)/lib/libquick.$(libsuffix); \
-	ln -s -f $(buildfolder)/lib/serial/libxc.$(libsuffix) $(amfolder)/lib/libxc.$(libsuffix); fi; \
-	if [ -e $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) $(amfolder)/lib/libquick-mpi.$(libsuffix); \
-	ln -s -f $(buildfolder)/lib/mpi/libxc.$(libsuffix) $(amfolder)/lib/libxc.$(libsuffix); fi; \
-	if [ -e $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) $(amfolder)/lib/libquick-cuda.$(libsuffix); \
-	ln -s -f $(buildfolder)/lib/cuda/libxc-cuda.$(libsuffix) $(amfolder)/lib/libxc-cuda.$(libsuffix); fi; \
-	if [ -e $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) $(amfolder)/lib/libquick-cudampi.$(libsuffix); \
-	ln -s -f $(buildfolder)/lib/cudampi/libxc-cuda.$(libsuffix) $(amfolder)/lib/libxc-cuda.$(libsuffix); fi; echo "Successfully installed QUICK libraries in $(amfolder)/lib folder.";\
-        else echo "Error: $(amfolder)/lib folder not found."; exit 1; fi
-	@if [ -d $(amfolder)/bin ]; then \
-	for i in quick quick.MPI quick.cuda quick.cuda.MPI; do if [ -x $(exefolder)/$$i ]; then mv $(exefolder)/$$i $(amfolder)/bin/; fi; done; \
-	echo "Successfully installed QUICK executables in $(amfolder)/bin folder."; \
-	else echo  "Error: $(amfolder)/bin folder not found."; exit 1; fi
+	@if [ -d $(installfolder)/lib ]; then \
+	if [ -e $(buildfolder)/lib/serial/libquick.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/serial/libquick.$(libsuffix) $(installfolder)/lib/libquick.$(libsuffix); \
+	ln -s -f $(buildfolder)/lib/serial/libxc.$(libsuffix) $(installfolder)/lib/libxc.$(libsuffix); fi; \
+	if [ -e $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) $(installfolder)/lib/libquick-mpi.$(libsuffix); \
+	ln -s -f $(buildfolder)/lib/mpi/libxc.$(libsuffix) $(installfolder)/lib/libxc.$(libsuffix); fi; \
+	if [ -e $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) $(installfolder)/lib/libquick-cuda.$(libsuffix); \
+	ln -s -f $(buildfolder)/lib/cuda/libxc-cuda.$(libsuffix) $(installfolder)/lib/libxc-cuda.$(libsuffix); fi; \
+	if [ -e $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) $(installfolder)/lib/libquick-cudampi.$(libsuffix); \
+	ln -s -f $(buildfolder)/lib/cudampi/libxc-cuda.$(libsuffix) $(installfolder)/lib/libxc-cuda.$(libsuffix); fi; echo "Successfully installed QUICK libraries in $(installfolder)/lib folder.";\
+        else echo "Error: $(installfolder)/lib folder not found."; exit 1; fi
+	@if [ -d $(installfolder)/bin ]; then \
+	for i in quick quick.MPI quick.cuda quick.cuda.MPI; do if [ -x $(exefolder)/$$i ]; then mv $(exefolder)/$$i $(installfolder)/bin/; fi; done; \
+	echo "Successfully installed QUICK executables in $(installfolder)/bin folder."; \
+	else echo  "Error: $(installfolder)/bin folder not found."; exit 1; fi
 
 
 #  !---------------------------------------------------------------------!
@@ -218,11 +218,11 @@ cudampiuninstall:
 	@-rm -rf $(installfolder)/lib/cudampi
 
 amuninstall:
-	@-rm -f $(amfolder)/bin/quick
-	@-rm -f $(amfolder)/bin/quick.MPI
-	@-rm -f $(amfolder)/bin/quick.cuda
-	@-rm -f $(amfolder)/bin/quick.cuda.MPI
-	@-rm -f $(amfolder)/lib/libquick*
-	@-rm -f $(amfolder)/lib/libxc.*
-	@-rm -f $(amfolder)/lib/libxc-cuda.*
-	@echo  "Successfully removed QUICK executables and libraries from $(amfolder) folder."
+	@-rm -f $(installfolder)/bin/quick
+	@-rm -f $(installfolder)/bin/quick.MPI
+	@-rm -f $(installfolder)/bin/quick.cuda
+	@-rm -f $(installfolder)/bin/quick.cuda.MPI
+	@-rm -f $(installfolder)/lib/libquick*
+	@-rm -f $(installfolder)/lib/libxc.*
+	@-rm -f $(installfolder)/lib/libxc-cuda.*
+	@echo  "Successfully removed QUICK executables and libraries from $(installfolder) folder."

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ cudampiinstall:
 	@cp -f $(buildfolder)/lib/cudampi/* $(installfolder)/lib/cudampi
 
 aminstall:
-	@if [ "$(AMINSTALL)" = 'true' ]; then \
+	@if [ -d $(amfolder)/lib ]; then \
 	if [ -e $(buildfolder)/lib/serial/libquick.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/serial/libquick.$(libsuffix) $(amfolder)/lib/libquick.$(libsuffix); \
 	ln -s -f $(buildfolder)/lib/serial/libxc.$(libsuffix) $(amfolder)/lib/libxc.$(libsuffix); fi; \
 	if [ -e $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/mpi/libquick-mpi.$(libsuffix) $(amfolder)/lib/libquick-mpi.$(libsuffix); \
@@ -115,10 +115,12 @@ aminstall:
 	if [ -e $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cuda/libquick-cuda.$(libsuffix) $(amfolder)/lib/libquick-cuda.$(libsuffix); \
 	ln -s -f $(buildfolder)/lib/cuda/libxc-cuda.$(libsuffix) $(amfolder)/lib/libxc-cuda.$(libsuffix); fi; \
 	if [ -e $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) ]; then ln -s -f $(buildfolder)/lib/cudampi/libquick-cudampi.$(libsuffix) $(amfolder)/lib/libquick-cudampi.$(libsuffix); \
-	ln -s -f $(buildfolder)/lib/cudampi/libxc-cuda.$(libsuffix) $(amfolder)/lib/libxc-cuda.$(libsuffix); fi; \
+	ln -s -f $(buildfolder)/lib/cudampi/libxc-cuda.$(libsuffix) $(amfolder)/lib/libxc-cuda.$(libsuffix); fi; echo "Successfully installed QUICK libraries in $(amfolder)/lib folder.";\
+        else echo "Error: $(amfolder)/lib folder not found."; exit 1; fi
+	@if [ -d $(amfolder)/bin ]; then \
 	for i in quick quick.MPI quick.cuda quick.cuda.MPI; do if [ -x $(exefolder)/$$i ]; then mv $(exefolder)/$$i $(amfolder)/bin/; fi; done; \
 	echo "Successfully installed QUICK executables in $(amfolder)/bin folder."; \
-	else echo  "Error: You must set the path to AMBER home directory before running 'make aminstall'."; fi
+	else echo  "Error: $(amfolder)/bin folder not found."; exit 1; fi
 
 
 #  !---------------------------------------------------------------------!
@@ -223,4 +225,4 @@ amuninstall:
 	@-rm -f $(amfolder)/lib/libquick*
 	@-rm -f $(amfolder)/lib/libxc.*
 	@-rm -f $(amfolder)/lib/libxc-cuda.*
-	@echo  "Successfully uninstalled QUICK executables in $(amfolder)/bin folder."
+	@echo  "Successfully removed QUICK executables and libraries from $(amfolder) folder."

--- a/configure
+++ b/configure
@@ -56,11 +56,11 @@ echo  "
       --nof          Disables the compilation of time consuming f functions 
                      in the ERI code of cuda version. Not recommended for 
                      production.
-      --amprefix <dir>
-                     Path to AMBER home directory
-                                                                            
-  Supported compilers are: gnu, intel, pgi                                       
-                                                                            
+      --amber        Install QUICK executables and libaries into AMBER. 
+                     Requires specifying AMBER home directory as prefix. 
+
+  Supported compilers are: gnu, intel, pgi
+
   For example, cuda version with intel compiler tool chain can be compiled as
   follows:
          ./configure --cuda --arch volta --prefix /home/install intel
@@ -480,7 +480,7 @@ ncores=''
 nof='no'
 
 # amber related variables
-useamprefix='false'
+aminstall='false'
 amprefix=''
 
 #  !---------------------------------------------------------------------!
@@ -497,10 +497,10 @@ while [ $# -gt 0 ]; do
     --debug)       debug='yes';;
     --shared)      shared='yes';;
     --nof)         nof='yes';;
+    --amber)       aminstall='true';;
     --arch)        shift; cuda_arch="$cuda_arch $1"; uspec_arch='true';;
     --ncores)      shift; ncores=$1; uspec_ncores='yes';;
     --prefix)      shift; quick_prefix=${1%/}; useprefix='true';;
-    --amprefix)    shift; amprefix=${1%/}; useamprefix='true';;
     gnu)           compiler='gnu';;
     intel)         compiler='intel';;
     pgi)           compiler='pgi';;
@@ -532,8 +532,38 @@ fi
 # check compiler
 check_compiler
 
-# check prefix and perform necessary operations
-if [ "$useprefix" = "true" ]; then
+# check is amber installtion is required
+if [ "$aminstall" = "true" ]; then
+
+  if [ "$useprefix" = "false" ]; then
+    echo "Error: AMBER compatible installation requires specifying the AMBER home directory as prefix."
+    exit 1
+  fi
+
+  # check for AMBER_HOME
+  if [ ! -d "$quick_prefix/AmberTools" ]; then
+    echo  "Error: Please provide the correct AMBER home directory."
+    exit 1
+  else
+    # do this trick to get absolute path
+    cd "$quick_prefix"
+    amprefix=`pwd`
+    cd "$QUICK_HOME"
+
+    echo "QUICK will be installed into $amprefix."
+
+    installtypes='aminstall'
+    uninstalltypes='amuninstall'
+
+    # reset $quick_prefix to prevent copying test script into AMBER_HOME
+    quick_prefix="$QUICK_HOME"    
+
+  fi
+
+fi
+
+# check prefix and perform necessary operations, we shall not create these for an amber installation
+if [ "$useprefix" = "true" ] && [ "$aminstall" = "false" ]; then
 
   if [ "$QUICK_HOME" = "$quick_prefix" ]; then
     echo  "Error: Specified --prefix and current folder is the same. Please choose a different location. "
@@ -592,30 +622,12 @@ if [ "$useprefix" = "true" ]; then
     installtypes="$installtypes $buildtype$install_string"
     uninstalltypes="$uninstalltypes $buildtype$uninstall_string"
   done
-
-else
-
-  echo "No prefix specified for the installation."
-
-  installtypes='noinstall'
-  uninstalltypes='nouninstall'
-
 fi
 
-# check amber prefix
-if [ "$useamprefix" = "true" ]; then
-
-  # do this trick to get absolute path
-  cd "$amprefix"
-  amprefix=`pwd`
-  cd "$QUICK_HOME"
-
-  if [ ! -d "$amprefix/bin" ]; then
-    echo  "Error: $amprefix/bin not found."
-    exit 1
-  else
-    echo "QUICK executables will be installed in $amprefix/bin folder."
-  fi
+if [ "$useprefix" = "false" ]; then
+  echo "No prefix specified for the installation."
+  installtypes='noinstall'
+  uninstalltypes='nouninstall'
 fi
 
 
@@ -917,7 +929,7 @@ for buildtype in $buildtypes; do
   fi
 
   # set the test type
-  if [ "$useprefix" = "true" ]; then
+  if [ "$useprefix" = "true" ] && [ "$aminstall" = "false" ]; then
     testtype='installtest'
   fi
 
@@ -1046,7 +1058,6 @@ SHARED=$shared
 
 INSTALLTYPES=$installtypes
 UNINSTALLTYPES=$uninstalltypes
-AMINSTALL=$useamprefix
 
 TESTTYPE=$testtype
 
@@ -1089,6 +1100,6 @@ fi
 
 echo  "          Run 'make test' to verify the executables."
 
-if [ "$useamprefix" = "true" ]; then
-echo  "          Run 'make aminstall' to install QUICK executables in $amprefix."
+if [ "$aminstall" = "true" ]; then
+echo  "          Run 'make install' to install QUICK executables and libraries into $amprefix."
 fi

--- a/configure
+++ b/configure
@@ -481,7 +481,6 @@ nof='no'
 
 # amber related variables
 aminstall='false'
-amprefix=''
 
 #  !---------------------------------------------------------------------!
 #  ! Check user input                                                    !
@@ -547,16 +546,13 @@ if [ "$aminstall" = "true" ]; then
   else
     # do this trick to get absolute path
     cd "$quick_prefix"
-    amprefix=`pwd`
+    quick_prefix=`pwd`
     cd "$QUICK_HOME"
 
-    echo "QUICK will be installed into $amprefix."
+    echo "QUICK will be installed into AMBER home directory $quick_prefix."
 
     installtypes='aminstall'
     uninstalltypes='amuninstall'
-
-    # reset $quick_prefix to prevent copying test script into AMBER_HOME
-    quick_prefix="$QUICK_HOME"    
 
   fi
 
@@ -1070,7 +1066,6 @@ exefolder=$QUICK_HOME/bin
 buildfolder=$QUICK_HOME/build
 toolsfolder=$QUICK_HOME/tools
 installfolder=$quick_prefix
-amfolder=$amprefix
 
 # source directories
 subfolder=$QUICK_HOME/src/subs
@@ -1101,5 +1096,5 @@ fi
 echo  "          Run 'make test' to verify the executables."
 
 if [ "$aminstall" = "true" ]; then
-echo  "          Run 'make install' to install QUICK executables and libraries into $amprefix."
+echo  "          Run 'make install' to install QUICK executables and libraries into AMBER home directory $quick_prefix."
 fi


### PR DESCRIPTION
I have made the following changes to configure script. 
1) Removed --amprefix and introduced --amber flag. 

This new flag requires the user to specify AMBER_HOME as --prefix. So one can configure for AMBER compatible QUICK installation as follows.
  `./configure --serial --mpi --cuda --cudampi --arch volta --shared --amber --prefix $AMBER_HOME gnu`

The script will verify the $AMBER_HOME by checking if AmberTools directory exist inside the given prefix.

2) Modified Makefiles to eliminate aminstall, amunistall dependency 
After the configuration, the user should run `make` and then `make install` to install executables  and libraries into bin and lib folders in $AMBER_HOME. We will check for the existence of bin and lib directories during `make install`. Uninstallation is done by running `make uninstall`. 