### PR TITLE
Bug fix for issue 34

### DIFF
--- a/src/modules/quick_scratch_module.f90
+++ b/src/modules/quick_scratch_module.f90
@@ -24,6 +24,8 @@ module quick_scratch_module
     
     type quick_scratch_type
         double precision, dimension(:,:), allocatable :: hold,hold2
+        ! magic variables required for classopt subroutine
+        double precision, dimension(:), allocatable :: X44,X44aa,X44bb,X44cc,X44dd  
     end type quick_scratch_type
     
     type (quick_scratch_type) quick_scratch
@@ -33,10 +35,18 @@ module quick_scratch_module
     interface alloc
         module procedure allocate_quick_scratch
     end interface alloc
-    
+
+    interface allocshellopt
+        module procedure allocate_shellopt_scratch
+    end interface allocshellopt
+
     interface dealloc
         module procedure deallocate_quick_scratch
-    end interface dealloc
+    end interface dealloc 
+
+    interface deallocshellopt
+        module procedure deallocate_shellopt_scratch
+    end interface deallocshellopt
     
     contains
         subroutine allocate_quick_scratch(self,nbasis)
@@ -61,6 +71,35 @@ module quick_scratch_module
             return
             
         end subroutine deallocate_quick_scratch
-        
+
+        subroutine allocate_shellopt_scratch(self,maxcontract)
+            implicit none
+            integer :: maxcontract, arraysize
+            type (quick_scratch_type) self
+
+            arraysize=maxcontract**4
+            if(.not. allocated(self%X44)) allocate(self%X44(arraysize))
+            if(.not. allocated(self%X44aa)) allocate(self%X44aa(arraysize))
+            if(.not. allocated(self%X44bb)) allocate(self%X44bb(arraysize))
+            if(.not. allocated(self%X44cc)) allocate(self%X44cc(arraysize))
+            if(.not. allocated(self%X44dd)) allocate(self%X44dd(arraysize))
+
+            return
+
+        end subroutine allocate_shellopt_scratch        
+
+        subroutine deallocate_shellopt_scratch(self)
+            implicit none
+            type (quick_scratch_type) self
+
+            if (allocated(self%X44)) deallocate(self%X44)
+            if (allocated(self%X44aa)) deallocate(self%X44aa)
+            if (allocated(self%X44bb)) deallocate(self%X44bb)
+            if (allocated(self%X44cc)) deallocate(self%X44cc)
+            if (allocated(self%X44dd)) deallocate(self%X44dd)
+
+            return
+
+        end subroutine deallocate_shellopt_scratch
 
 end module quick_scratch_module

--- a/src/shell.f90
+++ b/src/shell.f90
@@ -2169,6 +2169,9 @@ subroutine shellopt
    ! NNA=1
    ! NNC=1
 
+   ! allocate scratch memory for X arrays
+   call allocshellopt(quick_scratch,maxcontract)
+
    do I=NII1,NII2
       NNA=Sumindex(I-2)+1
       do J=NJJ1,NJJ2
@@ -2186,6 +2189,9 @@ subroutine shellopt
          enddo
       enddo
    enddo
+
+   ! deallocate scratch memory for X arrays
+   call deallocshellopt(quick_scratch)
 
 end subroutine shellopt
 
@@ -2207,12 +2213,12 @@ subroutine classopt(I,J,K,L,NNA,NNC,NNAB,NNCD,NNABfirst,NNCDfirst)
    Parameter(NN=14)
    double precision FM(0:13)
    double precision RA(3),RB(3),RC(3),RD(3)
-   double precision X44(129600)
+!   double precision X44(129600)
 
-   double precision X44aa(4096)
-   double precision X44bb(4096)
-   double precision X44cc(4096)
-   double precision X44dd(4096)
+!   double precision X44aa(4096)
+!   double precision X44bb(4096)
+!   double precision X44cc(4096)
+!   double precision X44dd(4096)
    double precision AA,BB,CC,DD
 
    COMMON /COM1/RA,RB,RC,RD
@@ -2244,10 +2250,10 @@ subroutine classopt(I,J,K,L,NNA,NNC,NNAB,NNCD,NNABfirst,NNCDfirst)
                cutoffprim=cutoffprim1*cutprim(Nprik,Npril)
                if(cutoffprim.gt.quick_method%gradCutoff)then
                   ITT=ITT+1
-                  X44(ITT)=X2*quick_basis%Xcoeff(Nprik,Npril,K,L)
-                  X44AA(ITT)=X44(ITT)*AA*2.0d0
-                  X44BB(ITT)=X44(ITT)*BB*2.0d0
-                  X44CC(ITT)=X44(ITT)*CC*2.0d0
+                  quick_scratch%X44(ITT)=X2*quick_basis%Xcoeff(Nprik,Npril,K,L)
+                  quick_scratch%X44AA(ITT)=quick_scratch%X44(ITT)*AA*2.0d0
+                  quick_scratch%X44BB(ITT)=quick_scratch%X44(ITT)*BB*2.0d0
+                  quick_scratch%X44CC(ITT)=quick_scratch%X44(ITT)*CC*2.0d0
                   !                       X44DD(ITT)=X44(ITT)*DD*2.0d0
                endif
             enddo
@@ -2264,7 +2270,7 @@ subroutine classopt(I,J,K,L,NNA,NNC,NNAB,NNCD,NNABfirst,NNCDfirst)
          !                           YtempBB=0.0d0
          !                           YtempCC=0.0d0
          do itemp=1,ITT
-            Ytemp=Ytemp+X44(itemp)*Yxiao(itemp,MM1,MM2)
+            Ytemp=Ytemp+quick_scratch%X44(itemp)*Yxiao(itemp,MM1,MM2)
             !                           YtempAA=YtempAA+X44AA(itemp)*Yxiao(itemp,MM1,MM2)
             !                           YtempBB=YtempBB+X44BB(itemp)*Yxiao(itemp,MM1,MM2)
             !                           YtempCC=YtempCC+X44CC(itemp)*Yxiao(itemp,MM1,MM2)
@@ -2285,9 +2291,9 @@ subroutine classopt(I,J,K,L,NNA,NNC,NNAB,NNCD,NNABfirst,NNCDfirst)
          YtempBB=0.0d0
          YtempCC=0.0d0
          do itemp=1,ITT
-            YtempAA=YtempAA+X44AA(itemp)*Yxiao(itemp,MM1,MM2)
-            YtempBB=YtempBB+X44BB(itemp)*Yxiao(itemp,MM1,MM2)
-            YtempCC=YtempCC+X44CC(itemp)*Yxiao(itemp,MM1,MM2)
+            YtempAA=YtempAA+quick_scratch%X44AA(itemp)*Yxiao(itemp,MM1,MM2)
+            YtempBB=YtempBB+quick_scratch%X44BB(itemp)*Yxiao(itemp,MM1,MM2)
+            YtempCC=YtempCC+quick_scratch%X44CC(itemp)*Yxiao(itemp,MM1,MM2)
 
             !                  if(II.eq.1.and.JJ.eq.1.and.KK.eq.13.and.LL.eq.13)then
             !                    print*,KKK-39,LLL-39,III+12,JJJ+12,itemp,X44AA(itemp),Yxiao(itemp,MM1,MM2)


### PR DESCRIPTION
This PR contains a fix for issue 34. Briefly, few large temporary arrays required for CPU ERI gradient code have been moved from stack memory to heap. Furthermore, the sizes of these arrays are now determined by the maximum number of primitive functions during the runtime.