### PR TITLE
Fixed different number of basis/primitive functions resulting from CPU and GPU OCTAGO versions

### DIFF
--- a/src/cuda/gpu.cu
+++ b/src/cuda/gpu.cu
@@ -1698,7 +1698,7 @@ void prune_grid_sswgrad(){
 }	
 
 
-void gpu_get_octree_info(QUICKDouble *gridx, QUICKDouble *gridy, QUICKDouble *gridz, QUICKDouble *sigrad2, unsigned char *gpweight, unsigned int *cfweight, unsigned int *pfweight, int count){
+void gpu_get_octree_info(QUICKDouble *gridx, QUICKDouble *gridy, QUICKDouble *gridz, QUICKDouble *sigrad2, unsigned char *gpweight, unsigned int *cfweight, unsigned int *pfweight, double DMCutoff,int count){
 
         PRINTDEBUG("BEGIN TO OBTAIN PRIMITIVE & BASIS FUNCTION LISTS ")
 
@@ -1723,7 +1723,7 @@ void gpu_get_octree_info(QUICKDouble *gridx, QUICKDouble *gridy, QUICKDouble *gr
         gpu -> gpu_sim.gridz    = gpu -> gpu_xcq -> gridz -> _devData;
 	gpu -> gpu_sim.sigrad2  = gpu->gpu_basis->sigrad2->_devData;
 
-	gpu -> gpu_cutoff -> DMCutoff   = 1E-9; //*DMCutoff;
+	gpu -> gpu_cutoff -> DMCutoff   = DMCutoff;
         gpu -> gpu_sim.DMCutoff         = gpu -> gpu_cutoff -> DMCutoff;
 
 	//Define cfweight and pfweight arrays seperately and uplaod to gpu until we solve the problem with atomicAdd

--- a/src/octree/gpack_common.h
+++ b/src/octree/gpack_common.h
@@ -4,4 +4,4 @@ static const int MAX_POINTS_PER_CLUSTER = 256;
 static const int OCTREE_DEPTH = 64;
 
 //void pack_grid_pts();
-extern "C" void gpu_get_octree_info(double *gridx, double *gridy, double *gridz, double *sigrad2, unsigned char *gpweight, unsigned int *cfweight, unsigned int *pfweight, int count);
+extern "C" void gpu_get_octree_info(double *gridx, double *gridy, double *gridz, double *sigrad2, unsigned char *gpweight, unsigned int *cfweight, unsigned int *pfweight, double DMCutoff, int count);

--- a/src/octree/grid_packer.cpp
+++ b/src/octree/grid_packer.cpp
@@ -596,7 +596,7 @@ void gpu_get_pfbased_basis_function_lists_new_imp(vector<node> *octree, vector<n
 
 	start = clock();
 
-        gpu_get_octree_info(gridx, gridy, gridz, gps->sigrad2->_cppData, gpweight, cfweight, pfweight, init_arr_size);
+        gpu_get_octree_info(gridx, gridy, gridz, gps->sigrad2->_cppData, gpweight, cfweight, pfweight, gps->DMCutoff, init_arr_size);
 
 	end = clock();
 


### PR DESCRIPTION
Turned out that I had hardcoded the cutoff in cuda code. I have fixed it in this PR. 