### PR TITLE
Error trap for f functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Brothers, E.; Götz, A.W.; Merz,K. M. QUICK-21.03 University of California San D
 
 License
 -------
-QUICK is licensed uder Mozilla Public License 2.0. More information can be found [here](https://quick-docs.readthedocs.io/en/21.3.0/license.html#mozilla-public-license-version-2-0).
+QUICK is licensed under Mozilla Public License 2.0. More information can be found [here](https://quick-docs.readthedocs.io/en/21.3.0/license.html#mozilla-public-license-version-2-0).
 
 Special Note to Users
 ---------------------

--- a/configure
+++ b/configure
@@ -1055,6 +1055,7 @@ for buildtype in $buildtypes; do
       ;;
   esac
 
+  fort_flags="$fort_flags -I$QUICK_HOME/src/util"
   cc_flags="$opt_flags $cc_debug_flags $lib_flags -I$QUICK_HOME/build/include/$buildtype"
   cxx_flags="$opt_flags $cxx_debug_flags $lib_flags -std=c++11 -I$QUICK_HOME/build/include/$buildtype"
 

--- a/configure
+++ b/configure
@@ -68,6 +68,10 @@ echo  "
       --mkl          Use matrix diagonalizer from MKL. MKLROOT environment
                      variable must be set with the correct mkl installation path.
                      This path must contain lib and include directories.
+      --mirp         Use Boys function for ERI calculations from mirp library. 
+                     MIRP_HOME and MIRP_DEP_HOME environment variables must be set to 
+                     mirp and dependency installation directories. These paths must 
+                     contain lib and include directories.
 
   Supported compilers are: gnu, intel, pgi, nvidia
 
@@ -465,6 +469,58 @@ check_lapack(){
     echo "OPENBLAS is not loaded. Inbuilt diagonalizer will be used."
     return 1
   fi
+}
+
+# Function to check for MIRP library and dependencies. 
+check_mirp(){
+
+if [ "$mirp" = 'yes' ] && [ "$shared" = 'no' ]; then
+  echo "Error: MIRP requires --shared flag. Plese reconfigure."
+  exit 1
+fi
+
+if [ -z "$MIRP_HOME" ]; then
+  echo "Error: MIRP_HOME is not set!"
+  exit 1
+else
+ # check for the so library
+  if [ ! -e "$MIRP_HOME/lib/libmirp.so" ]; then
+    echo "Error: libmirp.so cannot be found!"
+    exit 1
+  fi
+fi
+
+# check for dependencies
+if [ -z "$MIRP_DEP_HOME" ]; then
+  echo "Error: MIRP_DEP_HOME is not set!"
+  exit 1
+else
+
+# check for libarb.so
+if [ ! -e "$MIRP_DEP_HOME/lib/libarb.so" ]; then
+   echo "Error: libarb.so cannot be found!"
+   exit 1
+fi
+
+# check for libgmp.so
+if [ ! -e "$MIRP_DEP_HOME/lib/libgmp.so" ]; then
+   echo "Error: libgmp.so cannot be found!"
+   exit 1
+fi
+
+# check for libmpfr.so
+if [ ! -e "$MIRP_DEP_HOME/lib/libmpfr.so" ]; then
+   echo "Error: libmpfr.so cannot be found!"
+   exit 1
+fi
+
+# check for libflint.so
+if [ ! -e "$MIRP_DEP_HOME/lib/libflint.so" ]; then
+   echo "Error: libflint.so cannot be found!"
+   exit 1
+fi
+
+fi
 
 }
 
@@ -577,6 +633,9 @@ verbose='@'
 lapack='no'
 mkl='no'
 
+# flag for mirp library
+mirp='no'
+
 #  !---------------------------------------------------------------------!
 #  ! Check user input                                                    !
 #  !---------------------------------------------------------------------!
@@ -591,6 +650,7 @@ while [ $# -gt 0 ]; do
     --debug-time)  debugtime='yes';;
     --debug)       debug='yes';;
     --verbose)     verbose='';;
+    --mirp)        mirp='yes';;
     --shared)      shared='yes';;
     --nof)         nof='yes';;
     --amber)       aminstall='true';;
@@ -630,6 +690,11 @@ fi
 
 # check compiler
 check_compiler
+
+# check for dependencies
+if [ "$mirp" = "yes" ]; then
+  check_mirp
+fi
 
 # check is amber installtion is required
 if [ "$aminstall" = "true" ]; then
@@ -1039,8 +1104,9 @@ for buildtype in $buildtypes; do
     set_mpicxx
   fi
 
-  # For serial and mpi versions, diagonalizers from lapack/mkl may be used
   if [ "$buildtype" = 'serial' -o "$buildtype" = 'mpi' ]; then
+
+    # For serial and mpi versions, diagonalizers from lapack/mkl may be used
     if [ "$lapack" = 'yes' ]; then
       check_lapack
       if [ "$?" -eq 0 ]; then
@@ -1048,7 +1114,6 @@ for buildtype in $buildtypes; do
         fort_flags="$fort_flags -DLAPACK"
         ldflags="$ldflags -L$BLASROOT/lib -lopenblas"
       fi
-
     elif [ "$mkl" = 'yes' ]; then
       check_mkl
       if [ "$?" -eq 0 ]; then
@@ -1057,6 +1122,14 @@ for buildtype in $buildtypes; do
         ldflags="$ldflags -L$MKLROOT/lib/intel64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread"
       fi
     fi
+
+    # set mirp library flags
+    if [ "$mirp" = "yes" ]; then
+      fort_flags="$fort_flags -DMIRP"
+      cxx_flags="$cxx_flags -I$MIRP_HOME/include -I$MIRP_DEP_HOME/include -DMIRP"
+      ldflags="$ldflags -L$MIRP_HOME/lib -L$MIRP_DEP_HOME/lib -larb -lflint -lmirp"
+    fi
+
   fi
 
   # set the installer
@@ -1086,6 +1159,7 @@ for buildtype in $buildtypes; do
     libxcobjfolder="$QUICK_HOME/build/common/gpu/libxcobj"
     libxcdevobjfolder="$QUICK_HOME/build/common/gpu/libxcdevobj"
   fi
+
 
   # copy template Makefile into each buildtype directory
   cp -f "$QUICK_HOME/tools/build-makefile" "$QUICK_HOME/build/Makefile"
@@ -1251,6 +1325,12 @@ else
   for buildtype in $buildtypes; do
     libpaths="$libpath/$buildtype:$libpaths"
   done
+fi
+
+if [ "$buildtype" = 'serial' -o "$buildtype" = 'mpi' ]; then
+  if [ "$mirp" = "yes" ]; then
+    libpaths="$MIRP_HOME/lib:$MIRP_DEP_HOME/lib:$libpaths"
+  fi
 fi
 
 cat >> "$quick_prefix/quick.rc" << EOF

--- a/src/basis.f90
+++ b/src/basis.f90
@@ -89,7 +89,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
                      elseif (shell == 'F') then
                      quick_method%ffunxiao=.false.
                      kbasis(iat) = kbasis(iat) + 10
-                     ierr=10
                   end if
                   if (shell == 'SP') then
                      do i=1,iprim
@@ -605,6 +604,9 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
 
                            jshell = jshell+1
                            elseif (shell == 'F') then
+
+                           ierr=10 
+
                            quick_basis%ktype(jshell) = 10
                            quick_basis%katom(jshell) = i
                            quick_basis%kstart(jshell) = jbasis

--- a/src/basis.f90
+++ b/src/basis.f90
@@ -6,12 +6,13 @@
 !	Copyright 2011 University of Florida. All rights reserved.
 !
 
-subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal)
+subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ierr)
    !
    ! Read in the requested basisfile. This is done twice, once to get sizes and
    ! allocate variables, then again to assign the basis
    !
    use allmod
+   use quick_exception_module
    !
    implicit double precision(a-h,o-z)
    character(len=120) :: line
@@ -24,6 +25,8 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal)
    double precision AA(MAXPRIM),BB(MAXPRIM),CC(MAXPRIM)
    integer natomstart,natomfinal,nbasisstart,nbasisfinal
    double precision, allocatable,save, dimension(:) :: aex,gcs,gcp,gcd,gcf,gcg
+   integer :: ierr
+
 #ifdef MPIV
    include 'mpif.h'
 #endif
@@ -86,6 +89,7 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal)
                      elseif (shell == 'F') then
                      quick_method%ffunxiao=.false.
                      kbasis(iat) = kbasis(iat) + 10
+                     ierr=10
                   end if
                   if (shell == 'SP') then
                      do i=1,iprim

--- a/src/cuda/gpu_get2e_subs.h
+++ b/src/cuda/gpu_get2e_subs.h
@@ -1499,7 +1499,7 @@ __device__ __forceinline__ void FmT(int MaxM, QUICKDouble X, QUICKDouble* YVerti
                 3.79490003707156E-03  )*Y+1.61723488664661E-02  )*Y- \
               5.29428148329736E-02  )*Y+1.15702180856167E-01 ;
 	WW1 += (X+X)*F1;
-    }else if (X > 3.0E-5 || (X> 3.0E-7 && MaxM < 4)){
+    }else if (X > 1.0E-1 || (X> 1.0E-4 && MaxM < 4)){
         
         F1 =(((((((( -8.36313918003957E-08 *X+1.21222603512827E-06  )*X- \
                    1.15662609053481E-05  )*X+9.25197374512647E-05  )*X- \
@@ -1512,7 +1512,7 @@ __device__ __forceinline__ void FmT(int MaxM, QUICKDouble X, QUICKDouble* YVerti
     }
     
     
-    if (X > 3.0E-5 || (X> 3.0E-7 && MaxM < 4)) {
+    if (X > 1.0E-1 || (X> 1.0E-4 && MaxM < 4)) {
         LOC3(YVerticalTemp, 0, 0, 0, VDIM1, VDIM2, VDIM3) = WW1;
         for (int m = 1; m<= MaxM; m++) {
             LOC3(YVerticalTemp, 0, 0, m, VDIM1, VDIM2, VDIM3) = (((2*m-1)*LOC3(YVerticalTemp, 0, 0, m-1, VDIM1, VDIM2, VDIM3))- E)*0.5*XINV;
@@ -1525,6 +1525,7 @@ __device__ __forceinline__ void FmT(int MaxM, QUICKDouble X, QUICKDouble* YVerti
     }
     return;
 }
+
 
 /*
  sqr for double precision. there no internal function to do that in fast-math-lib of CUDA

--- a/src/finalize.f90
+++ b/src/finalize.f90
@@ -79,7 +79,7 @@ subroutine finalize(io,status,option)
         endif
     endif
 
-    call timer_output(io)
+    if (status == 0) call timer_output(io)
        
     if (master) then
         if (status ==0) then
@@ -118,14 +118,17 @@ subroutine quick_exit(io, status)
 
    if (status /= 0) then
       call flush(io)
-#ifdef MPIV
-      call mpi_abort(MPI_COMM_WORLD, status, ierr)
-   else
-      call mpi_finalize(ierr)
-#endif
    end if
 
    call finalize(io,1,0)
+
+#ifdef MPIV
+   if (status /= 0) then
+     call mpi_abort(MPI_COMM_WORLD, status, ierr)
+   else
+     call mpi_finalize(ierr)
+   endif
+#endif
 
    call exit(status)
 

--- a/src/getMol.f90
+++ b/src/getMol.f90
@@ -7,10 +7,14 @@
 !	Copyright 2011 University of Florida. All rights reserved.
 !
 
-subroutine getMol()
+#include "util.fh"
+
+subroutine getMol(ierr)
    ! This subroutine is to get molecule information
    ! and assign basis function.
    use allmod
+   use quick_exception_module
+
    implicit none
 
 #ifdef MPIV
@@ -18,7 +22,7 @@ subroutine getMol()
 #endif
 
    logical :: present
-   integer :: i,j,k,itemp
+   integer :: i,j,k,itemp, ierr
 
    !-----------MPI/MASTER------------------------
    if (master) then
@@ -67,7 +71,8 @@ subroutine getMol()
    ! At this point we have the positions and identities of the atoms. We also
    ! have the number of electrons. Now we must assign basis functions. This
    ! is done in a subroutine.
-   call readbasis(natom,0,0,0,0)
+   call readbasis(natom,0,0,0,0,ierr)
+   CHECK_ERROR(ierr)
 
    quick_molspec%nbasis   => nbasis
    quick_qm_struct%nbasis => nbasis

--- a/src/getMolSad.f90
+++ b/src/getMolSad.f90
@@ -12,9 +12,13 @@
 ! file, You can obtain one at http://mozilla.org/MPL/2.0/.            !
 !_____________________________________________________________________!
 
-subroutine getmolsad()
+#include "util.fh"
+
+subroutine getmolsad(ierr)
    use allmod
    use quick_files_module
+   use quick_exception_module
+
    implicit double precision(a-h,o-z)
 
    logical :: present,MPIsaved
@@ -24,6 +28,7 @@ subroutine getmolsad()
    integer natomsaved
    type(quick_method_type) quick_method_save
    type(quick_molspec_type) quick_molspec_save
+   integer :: ierr
 
    ! first save some important value
    quick_method_save=quick_method
@@ -104,7 +109,9 @@ subroutine getmolsad()
          ! is done in a subroutine.
          !-------------------------------------------
          nsenhai=1
-         call readbasis(nsenhai,0,0,0,0)
+         call readbasis(nsenhai,0,0,0,0,ierr)
+         CHECK_ERROR(ierr)
+         
          atombasis(iitemp)=nbasis
          write (ioutfile,'(" BASIS FUNCTIONS = ",I4)') nbasis
 

--- a/src/main.f90
+++ b/src/main.f90
@@ -141,7 +141,7 @@
     call cpu_time(timer_begin%TIniGuess)
 
     ! a. SAD intial guess
-    if (quick_method%SAD) call getMolSad()
+    if (quick_method%SAD) call getMolSad(ierr)
 
     ! b. MFCC initial guess
     if (quick_method%MFCC) then
@@ -152,7 +152,7 @@
     !------------------------------------------------------------------
     ! 3. Read Molecule Structure
     !-----------------------------------------------------------------
-    call getMol()
+    call getMol(ierr)
 
 #if defined CUDA || defined CUDA_MPIV
     call gpu_setup(natom,nbasis, quick_molspec%nElec, quick_molspec%imult, &

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -25,11 +25,11 @@ include $(MAKEIN)
 
 FOR=$(FC) $(FFLAGS)
 
-modobj=$(objfolder)/quick_mpi_module.o $(objfolder)/quick_constants_module.o $(objfolder)/quick_method_module.o \
+modobj=$(objfolder)/quick_files_module.o $(objfolder)/quick_mpi_module.o $(objfolder)/quick_constants_module.o $(objfolder)/quick_method_module.o \
 		$(objfolder)/quick_molspec_module.o $(objfolder)/quick_gaussian_class_module.o $(objfolder)/quick_size_module.o \
 		$(objfolder)/quick_amber_interface_module.o $(objfolder)/quick_basis_module.o $(objfolder)/quick_calculated_module.o \
 		$(objfolder)/quick_divcon_module.o $(objfolder)/quick_ecp_module.o $(objfolder)/quick_electrondensity_module.o \
-		$(objfolder)/quick_files_module.o $(objfolder)/quick_timer_module.o $(objfolder)/quick_gridpoints_module.o \
+		$(objfolder)/quick_timer_module.o $(objfolder)/quick_gridpoints_module.o \
 		$(objfolder)/quick_mfcc_module.o $(objfolder)/quick_params_module.o $(objfolder)/quick_pb_module.o \
 		$(objfolder)/quick_scratch_module.o $(objfolder)/quick_all_module.o $(objfolder)/quick_scf_module.o \
 		$(objfolder)/quick_cutoff_module.o $(objfolder)/quick_gradient_module.o \

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -25,7 +25,8 @@ include $(MAKEIN)
 
 FOR=$(FC) $(FFLAGS)
 
-modobj=$(objfolder)/quick_files_module.o $(objfolder)/quick_mpi_module.o $(objfolder)/quick_constants_module.o $(objfolder)/quick_method_module.o \
+modobj=$(objfolder)/quick_exception_module.o $(objfolder)/quick_files_module.o $(objfolder)/quick_mpi_module.o \
+		$(objfolder)/quick_constants_module.o $(objfolder)/quick_method_module.o \
 		$(objfolder)/quick_molspec_module.o $(objfolder)/quick_gaussian_class_module.o $(objfolder)/quick_size_module.o \
 		$(objfolder)/quick_amber_interface_module.o $(objfolder)/quick_basis_module.o $(objfolder)/quick_calculated_module.o \
 		$(objfolder)/quick_divcon_module.o $(objfolder)/quick_ecp_module.o $(objfolder)/quick_electrondensity_module.o \

--- a/src/modules/quick_api_module.f90
+++ b/src/modules/quick_api_module.f90
@@ -401,6 +401,7 @@ subroutine run_quick(self)
   type(quick_api_type), intent(inout) :: self
   integer :: ierr, i, j, k
   logical :: failed = .false.
+  ierr=0
 
   ! print step into quick output file
   call print_step(self)
@@ -420,10 +421,10 @@ subroutine run_quick(self)
   if(self%firstStep .and. self%reuse_dmx) then
 
     ! perform the initial guess
-    if (quick_method%SAD) call getMolSad()
+    if (quick_method%SAD) call getMolSad(ierr)
 
     ! assign basis functions
-    call getMol()
+    call getMol(ierr)
 
     self%firstStep = .false.
 

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -17,8 +17,27 @@ module quick_exception_module
 
   implicit none
   private
+  public :: RaiseException
+
+  interface RaiseException
+    module procedure raise_exception
+  end interface
 
 contains
+
+  ! raises exceptions
+  subroutine raise_exception(ierr)
+
+    use quick_files_module
+    implicit none
+    integer, intent(in) :: ierr
+
+    if (ierr /= 0) then
+      call print_exception(iOutFile, ierr)
+      call quick_exit(iOutFile,1)
+    endif
+
+  end subroutine
 
 
 

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -13,6 +13,8 @@
 ! This module performs exception handling in QUICK.                   !
 !_____________________________________________________________________!
 
+#include "util.fh"
+
 module quick_exception_module
 
   implicit none

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -35,17 +35,17 @@ contains
     integer, intent(in) :: ierr
 
     if (ierr /= 0) then
-      call print_exception(ioutfile, ierr)
-      call quick_exit(ioutfile,1)
+      call print_exception(ierr)
+      call quick_exit(OUTFILEHANDLE,1)
     endif
 
   end subroutine raise_exception
 
   ! picks an error message and prints
-  subroutine print_exception(ioutfile, ierr)
+  subroutine print_exception(ierr)
 
     implicit none
-    integer, intent(in) :: ioutfile, ierr
+    integer, intent(in) :: ierr
     character(len=200) :: msg = ''
 
     select case(ierr)
@@ -55,7 +55,7 @@ contains
 
     end select
 
-    call PrtErr(ioutfile, trim(msg))
+    call PrtErr(OUTFILEHANDLE, trim(msg))
 
   end subroutine
 

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -30,7 +30,6 @@ contains
   ! raises exceptions
   subroutine raise_exception(ierr)
 
-    use quick_files_module
     implicit none
     integer, intent(in) :: ierr
 
@@ -53,7 +52,7 @@ contains
     case(10)
       msg='f basis functions are currently not supported.'
 
-    default case
+    case default
       msg='Unknown error.'
 
     end select

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -1,5 +1,5 @@
 !---------------------------------------------------------------------!
-! Created by Madu Manathunga on 04/16/2020                            !
+! Created by Madu Manathunga on 02/25/2020                            !
 !                                                                     !
 ! Copyright (C) 2020-2021 Merz lab                                    !
 ! Copyright (C) 2020-2021 Götz lab                                    !

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -33,12 +33,28 @@ contains
     integer, intent(in) :: ierr
 
     if (ierr /= 0) then
-      call print_exception(iOutFile, ierr)
-      call quick_exit(iOutFile,1)
+      call print_exception(ioutfile, ierr)
+      call quick_exit(ioutfile,1)
     endif
 
+  end subroutine raise_exception
+
+  ! picks an error message and prints
+  subroutine print_exception(ioutfile, ierr)
+
+    implicit none
+    integer, intent(in) :: ioutfile, ierr
+    character(len=200) :: msg = ''
+
+    select case(ierr)
+
+    case(10)
+      msg='f basis functions are currently not supported.'
+
+    end select
+
+    call PrtErr(ioutfile, trim(msg))
+
   end subroutine
-
-
 
 end module quick_exception_module

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -1,0 +1,25 @@
+!---------------------------------------------------------------------!
+! Created by Madu Manathunga on 04/16/2020                            !
+!                                                                     !
+! Copyright (C) 2020-2021 Merz lab                                    !
+! Copyright (C) 2020-2021 Götz lab                                    !
+!                                                                     !
+! This Source Code Form is subject to the terms of the Mozilla Public !
+! License, v. 2.0. If a copy of the MPL was not distributed with this !
+! file, You can obtain one at http://mozilla.org/MPL/2.0/.            !
+!_____________________________________________________________________!
+
+!---------------------------------------------------------------------!
+! This module performs exception handling in QUICK.                   !
+!_____________________________________________________________________!
+
+module quick_exception_module
+
+  implicit none
+  private
+
+contains
+
+
+
+end module quick_exception_module

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -53,6 +53,9 @@ contains
     case(10)
       msg='f basis functions are currently not supported.'
 
+    default case
+      msg='Unknown error.'
+
     end select
 
     call PrtErr(OUTFILEHANDLE, trim(msg))

--- a/src/modules/quick_files_module.f90
+++ b/src/modules/quick_files_module.f90
@@ -12,6 +12,8 @@
 ! file, You can obtain one at http://mozilla.org/MPL/2.0/.            !
 !_____________________________________________________________________!
 
+#include "util.fh"
+
 !  File module.
 module quick_files_module
 !------------------------------------------------------------------------
@@ -48,17 +50,17 @@ module quick_files_module
     character(len=80) :: basisCustName  = ''
     character(len=80) :: PDBFileName    = ''
 
-    integer :: inFile         = 2020    ! input file
-    integer :: iOutFile       = 2021    ! output file
-    integer :: iDmxFile       = 2022    ! density matrix file
-    integer :: iRstFile       = 2023    ! Restricted file
-    integer :: iCPHFFile      = 2024    ! CPHF file
-    integer :: iBasisFile     = 2025    ! basis set file
-    integer :: iECPFile       = 2026    ! ECP file
-    integer :: iBasisCustFile = 2027    ! custom basis set file
-    integer :: iPDBFile       = 2028    ! PDB input file
-    integer :: iDataFile      = 2029    ! Data file, similar to chk file in gaussian
-    integer :: iIntFile       = 2030    ! integral file
+    integer :: inFile         = INFILEHANDLE     ! input file
+    integer :: iOutFile       = OUTFILEHANDLE    ! output file
+    integer :: iDmxFile       = 2022             ! density matrix file
+    integer :: iRstFile       = 2023             ! Restricted file
+    integer :: iCPHFFile      = 2024             ! CPHF file
+    integer :: iBasisFile     = 2025             ! basis set file
+    integer :: iECPFile       = 2026             ! ECP file
+    integer :: iBasisCustFile = 2027             ! custom basis set file
+    integer :: iPDBFile       = 2028             ! PDB input file
+    integer :: iDataFile      = DATAFILEHANDLE   ! Data file, similar to chk file in gaussian
+    integer :: iIntFile       = 2030             ! integral file
 
     logical :: fexist = .false.         ! Check if file exists
 

--- a/src/shell.f90
+++ b/src/shell.f90
@@ -656,8 +656,11 @@ subroutine shell
                   !                         2m        2
                   ! Fm(T) = integral(1,0) {t   exp(-Tt )dt}
                   ! NABCD is the m value, and FM returns the FmT value
+#ifdef MIRP
+                  call mirp_fmt(NABCD,T,FM)
+#else
                   call FmT(NABCD,T,FM)
-
+#endif
                   !Go through all m values, obtain Fm values from FM array we
                   !just computed and calculate quantities required for HGP Eqn
                   !12. 

--- a/src/subs/Makefile
+++ b/src/subs/Makefile
@@ -42,6 +42,8 @@ SUBS = $(objfolder)/Angles.o $(objfolder)/copyDMat.o $(objfolder)/copySym.o \
 	$(objfolder)/pt2der.o $(objfolder)/sswder.o $(objfolder)/denspt_new_imp.o \
 	$(objfolder)/pteval_new_imp.o $(objfolder)/scaMatMul.o 
 
+MIRP = $(objfolder)/mirp_fmt.o
+
 #  !---------------------------------------------------------------------!
 #  ! Build targets                                                       !
 #  !---------------------------------------------------------------------!
@@ -49,8 +51,11 @@ SUBS = $(objfolder)/Angles.o $(objfolder)/copyDMat.o $(objfolder)/copySym.o \
 $(SUBS):$(objfolder)/%.o:%.f90
 	@echo "[QUICK]  FC $@"
 	$(VB)$(FOR) -c $< -o $@
+$(MIRP):$(objfolder)/%.o:%.cpp
+	@echo "[QUICK]  CXX $@"
+	$(VB)$(CXX) $(CXXFLAGS) -c $< -o $@
 
-all: $(SUBS)
+all: $(SUBS) $(MIRP)
 
 #  !---------------------------------------------------------------------!
 #  ! Cleaning targets                                                    !

--- a/src/subs/fmt.f90
+++ b/src/subs/fmt.f90
@@ -56,7 +56,7 @@ Subroutine FmT(MaxM,X,vals)
              5.29428148329736d-02 )*Y+1.15702180856167d-01
         WW1 = (X+X)*F1+E
      endif
-  else if (X > 3.0d-05 .or. (X>3.0d-07.and.maxm<4)) then
+  else if (X > 1.0d-01 .or. (X>1.0d-04.and.maxm<4)) then
      F1 =((((((((-8.36313918003957d-08*X+1.21222603512827d-06 )*X- &
           1.15662609053481d-05 )*X+9.25197374512647d-05 )*X- &
           6.40994113129432d-04 )*X+3.78787044215009d-03 )*X- &
@@ -68,7 +68,7 @@ Subroutine FmT(MaxM,X,vals)
      WW1 = (1.d0-X)/dble(2*maxm+1)
   endif
 
-  if (X > 3.0d-5 .or. (X>3.0d-07.and.maxm<4) ) then
+  if (X > 1.0d-1 .or. (X>1.0d-04.and.maxm<4) ) then
      vals(0) = WW1
      do m=1,maxm
         vals(m) = (((2*m-1)*vals(m-1))- E)*0.5d0*XINV

--- a/src/subs/mirp_fmt.cpp
+++ b/src/subs/mirp_fmt.cpp
@@ -1,0 +1,36 @@
+/*
+  !---------------------------------------------------------------------!
+  ! Written by Madu Manathunga on 02/05/2021                            !
+  !                                                                     ! 
+  ! Copyright (C) 2020-2021 Merz lab                                    !
+  ! Copyright (C) 2020-2021 Götz lab                                    !
+  !                                                                     !
+  ! This Source Code Form is subject to the terms of the Mozilla Public !
+  ! License, v. 2.0. If a copy of the MPL was not distributed with this !
+  ! file, You can obtain one at http://mozilla.org/MPL/2.0/.            !
+  !_____________________________________________________________________!
+
+  !---------------------------------------------------------------------!
+  ! This source file contains wrapper functions required to use FmT     !
+  ! function from MIRP library.                                         !
+  !                                                                     ! 
+  !---------------------------------------------------------------------!
+*/
+#ifdef MIRP
+#include <mirp/kernels/boys.h>
+#include <mirp/math.h>
+
+#include <iostream>
+#include "mirp_fmt.hpp"
+
+// Fortran accessible fmt function from mirp library
+void mirp_fmt_(int *m, double *t, double *fmt){
+
+  double *F = new double[*m+1]();
+
+  mirp_boys_exact(F, *m, *t);
+
+  for(int i=0; i<=*m+1; ++i) fmt[i]=F[i];
+
+}
+#endif

--- a/src/subs/mirp_fmt.hpp
+++ b/src/subs/mirp_fmt.hpp
@@ -1,0 +1,10 @@
+
+#ifndef __MIRP_FMT_H__
+#define __MIRP_FMT_H__
+
+extern "C" {
+void mirp_fmt_(int *m, double *t, double *fmt);
+}
+
+#endif
+

--- a/src/util/util.fh
+++ b/src/util/util.fh
@@ -18,3 +18,14 @@
 #define OUTFILEHANDLE  2021
 #define DATAFILEHANDLE 2029
 
+! For the following definitions to work, one must use quick_exception_module
+! in a subroutine. 
+
+#if defined DEBUG || defined DEBUGTIME
+#define CHECK_ERROR(ierr) 
+#else
+#define CHECK_ERROR(ierr) if(ierr /= 0) call RaiseException(ierr) 
+#endif
+
+
+

--- a/src/util/util.fh
+++ b/src/util/util.fh
@@ -14,5 +14,7 @@
 ! in f90 source files.                                                !
 !_____________________________________________________________________!
 
-#define OUTFILEHANDLE 2021 
+#define INFILEHANDLE   2020
+#define OUTFILEHANDLE  2021
+#define DATAFILEHANDLE 2029
 

--- a/src/util/util.fh
+++ b/src/util/util.fh
@@ -19,12 +19,17 @@
 #define DATAFILEHANDLE 2029
 
 ! For the following definitions to work, one must use quick_exception_module
-! in a subroutine. 
+! in a subroutine. For MPI/CUDAMPI versions, quick_mpi_module must be used. 
 
 #if defined DEBUG || defined DEBUGTIME
 #define CHECK_ERROR(ierr) 
 #else
-#define CHECK_ERROR(ierr) if(ierr /= 0) call RaiseException(ierr) 
+#ifdef MPIV
+#define CHECK_ERR if(master .and. ierr /= 0)
+#else
+#define CHECK_ERR if(ierr /= 0)
+#endif
+#define CHECK_ERROR(ierr) CHECK_ERR call RaiseException(ierr) 
 #endif
 
 

--- a/src/util/util.fh
+++ b/src/util/util.fh
@@ -1,0 +1,18 @@
+!---------------------------------------------------------------------!
+! Created by Madu Manathunga on 02/25/2021                            !
+!                                                                     !
+! Copyright (C) 2020-2021 Merz lab                                    !
+! Copyright (C) 2020-2021 Götz lab                                    !
+!                                                                     !
+! This Source Code Form is subject to the terms of the Mozilla Public !
+! License, v. 2.0. If a copy of the MPL was not distributed with this !
+! file, You can obtain one at http://mozilla.org/MPL/2.0/.            !
+!_____________________________________________________________________!
+
+!---------------------------------------------------------------------!
+! This header file contains macro definitions. Must be only included  !
+! in f90 source files.                                                !
+!_____________________________________________________________________!
+
+#define OUTFILEHANDLE 2021 
+


### PR DESCRIPTION
This PR contains an error trap to prevent users from using f functions and should fix issue #83. 

I have done this by implementing a new error handling scheme. Specifically, I have added a new module (quick_exception_module.f90, contains a couple of subroutines related to error handling) and a fortran header file (util.fh, contains some macro definitions). 
To handle new exceptions, developers must include util.fh in fortran source file and use quick_exception_module in subroutines. The error code and message must be set in the case statement in print_exception subroutine. The error code must be thrown from an appropriate place of a subroutine and caught using CHECK_ERROR() macro immediately after calling that subroutine. 
Note that exception handling will be disabled in debug/debug-time modes. This is important for stack tracing and debugging using debuggers.  