### PR TITLE
Fix for issue 87

### DIFF
--- a/src/cuda/gpu_common.h
+++ b/src/cuda/gpu_common.h
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <cuda.h>
+#include <cuda_runtime_api.h>
 #include "nvToolsExt.h"
 #include "../octree/gpack_common.h"
 

--- a/src/cuda/gpu_type.h
+++ b/src/cuda/gpu_type.h
@@ -656,7 +656,7 @@ void cuda_buffer_type<T> :: ReallocateGPU()
 
    cudaError_t status;
 
-   if (_devData == NULL) // if not constructed from f90 array
+   if (_devData == NULL) // if memory has not been allocated
     {
         if (!_bPinned) {
             //Allocate GPU memeory
@@ -672,7 +672,13 @@ void cuda_buffer_type<T> :: ReallocateGPU()
 
         }
     }else{
-        status=cudaErrorNotMappedAsPointer;
+#ifndef CUDART_VERSION
+       status=cudaErrorInvalidValue
+#elif (CUDART_VERSION < 10010)
+       status=cudaErrorInvalidDevicePointer;
+#else
+       status=cudaErrorNotMappedAsPointer;
+#endif
         PRINTERROR(status, " cudaMalloc cuda_buffer_type :: Reallocation failed!");
     }
 


### PR DESCRIPTION
This PR contains a fix for the compile time error reported in issue #87. The problem was caused by usage of `cudaErrorNotMappedAsPointer ` error type which was introduced since CUDA/10.1. This has been fixed by selecting correct error type based on the CUDA toolkit version. 