### PR TITLE
More CMake updates

### DIFF
--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          bin/quick_runtest --mpi --ncores 2
+          bin/runtest --mpi --ncores 2

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          runtest --mpi --ncores 2
+          ./runtest --mpi --ncores 2

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -49,4 +49,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          bin/runtest --mpi --ncores 2
+          runtest --mpi --ncores 2

--- a/.github/workflows/serial.yml
+++ b/.github/workflows/serial.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          bin/runtest --serial
+          runtest --serial

--- a/.github/workflows/serial.yml
+++ b/.github/workflows/serial.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          runtest --serial
+          ./runtest --serial

--- a/.github/workflows/serial.yml
+++ b/.github/workflows/serial.yml
@@ -47,5 +47,4 @@ jobs:
       - name: Test serial
         run: |
           cd install
-          bin/quick_runtest --serial
-
+          bin/runtest --serial

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ else()
 	install(DIRECTORY test DESTINATION . USE_SOURCE_PERMISSIONS)
 
 	# install scripts
-	install(PROGRAMS tools/runtest DESTINATION ${BINDIR} RENAME quick_runtest)
+	install(PROGRAMS tools/runtest DESTINATION ${BINDIR})
 	install(PROGRAMS quick-cmake/quick.rc DESTINATION ${BINDIR})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,12 @@ cmake_minimum_required(VERSION 3.9.0) # version 3.9.0 needed for FindMPI and Fin
 
 project(quick LANGUAGES NONE VERSION 20.03)
 
-
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quick-cmake)
 if(NOT INSIDE_AMBER)
 
 	# initialization and include paths
 	#-------------------------------------------------------------
 	include(cmake/AmberBuildSystemInit.cmake NO_POLICY_SCOPE)
-	list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quick-cmake)
 
 	#now enable the languages
 	enable_language(C CXX Fortran)
@@ -45,7 +44,15 @@ option(NOF "Disables the compilation of QUICK's time consuming f functions in th
 set_property(DIRECTORY . PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG>)
 
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+
+	# QUICK needs to be built with -O2 not Amber's default of -O3
+	if(OPTIMIZE)
+		list(APPEND OPT_CFLAGS -O2)
+		set(OPT_CFLAGS_SPC "${OPT_CFLAGS_SPC} -O2")
+	endif()
+
+elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -traceback")
 endif()
 
@@ -53,6 +60,11 @@ endif()
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
 	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
 	add_definitions(-DGNU)
+
+	if(OPTIMIZE)
+		list(APPEND OPT_FFLAGS -O2)
+		set(OPT_FFLAGS_SPC "${OPT_FFLAGS_SPC} -O2")
+	endif()
 
 	if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
 		set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,10 +157,10 @@ else()
 	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/amber-modules/ DESTINATION ./include)
 
 	# install data in basis dir
-	install(DIRECTORY basis DESTINATION .)
+	install(DIRECTORY basis DESTINATION . USE_SOURCE_PERMISSIONS)
 
 	# install tests dir
-	install(DIRECTORY test DESTINATION .)
+	install(DIRECTORY test DESTINATION . USE_SOURCE_PERMISSIONS)
 
 	# install scripts
 	install(PROGRAMS tools/runtest DESTINATION ${BINDIR} RENAME quick_runtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,29 +115,33 @@ include(QUICKCudaConfig)
 
 add_subdirectory(src)
 
-#--------------------------------------------------------------	
-# Exported targets
+if(NOT INSIDE_AMBER) # Amber is currently not set up for exported targets
 
-# directory relative to prefix where config files will be installed
-set(CMAKE_PACKAGE_CONFIG_DIR share/cmake/QUICK)
+	#--------------------------------------------------------------	
+	# Exported targets
 
-# install targets file
-install(EXPORT QUICK 
-	FILE QUICKTargets.cmake
-	NAMESPACE QUICK::
-	DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
+	# directory relative to prefix where config files will be installed
+	set(CMAKE_PACKAGE_CONFIG_DIR share/cmake/QUICK)
 
-# install version file
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QUICKConfigVersion.cmake
-	VERSION ${${PROJECT_NAME}_VERSION}
-	COMPATIBILITY AnyNewerVersion)
+	# install targets file
+	install(EXPORT QUICK 
+		FILE QUICKTargets.cmake
+		NAMESPACE QUICK::
+		DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
 
-# install top-level file
-configure_package_config_file(QUICKConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfig.cmake
-	INSTALL_DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
+	# install version file
+	include(CMakePackageConfigHelpers)
+	write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QUICKConfigVersion.cmake
+		VERSION ${${PROJECT_NAME}_VERSION}
+		COMPATIBILITY AnyNewerVersion)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfig.cmake DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
+	# install top-level file
+	configure_package_config_file(QUICKConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfig.cmake
+		INSTALL_DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
+
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/QUICKConfig.cmake DESTINATION ${CMAKE_PACKAGE_CONFIG_DIR})
+
+endif()
 
 #--------------------------------------------------------------	
 # Additional files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ else()
 	install(DIRECTORY test DESTINATION . USE_SOURCE_PERMISSIONS)
 
 	# install scripts
-	install(PROGRAMS tools/runtest DESTINATION ${BINDIR})
+	install(PROGRAMS tools/runtest DESTINATION .)
 	install(PROGRAMS quick-cmake/quick.rc DESTINATION ${BINDIR})
 endif()
 

--- a/cmake/ConfigModuleDirs.cmake
+++ b/cmake/ConfigModuleDirs.cmake
@@ -12,9 +12,11 @@ function(config_module_dirs TARGETNAME TARGET_MODULE_DIR) #3rd optional argument
 	if(IS_ABSOLUTE "${TARGET_MODULE_DIR}")
 		# legacy full path, pass through unmodified
 		set(INCLUDE_DIRS ${TARGET_MODULE_DIR})
+		set(MODULE_OUTPUT_DIR ${TARGET_MODULE_DIR})
 	else()
 		# add both the build dir path and the installed path
 		set(INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR}> $<INSTALL_INTERFACE:include/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR}>)
+		set(MODULE_OUTPUT_DIR ${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR})
 	endif()
 
 	# convert relative module paths being included to absolute
@@ -49,7 +51,7 @@ function(config_module_dirs TARGETNAME TARGET_MODULE_DIR) #3rd optional argument
 	endforeach()
 
 	# combine the new module dirs with the rest of the include dirs
-	set_property(TARGET ${TARGETNAME} PROPERTY Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR})
+	set_property(TARGET ${TARGETNAME} PROPERTY Fortran_MODULE_DIRECTORY ${MODULE_OUTPUT_DIR})
 	set_property(TARGET ${TARGETNAME} PROPERTY INCLUDE_DIRECTORIES ${INCLUDE_DIRS} ${LEFTOVER_INC_DIRS})
 	set_property(TARGET ${TARGETNAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${INCLUDE_DIRS} ${LEFTOVER_INT_INC_DIRS})
 	

--- a/cmake/ConfigModuleDirs.cmake
+++ b/cmake/ConfigModuleDirs.cmake
@@ -1,5 +1,5 @@
-#Function which (a) sets the module output directory for a target, and (b) includes other module directories
-#preserves the include directories already set on the target, adding them at the end of the list.
+#Function which (a) sets the module output directory for a target, and (b) includes other module directories.
+#Preserves the include directories already set on the target, adding them at the end of the list.
 
 # It removes all previous include directories pointing to Amber's modules folder,
 # so that if you use copy_target() you can set new module paths without leaving the old ones lingering
@@ -9,15 +9,25 @@ set(MODULE_DIR_NAME amber-modules)
 
 function(config_module_dirs TARGETNAME TARGET_MODULE_DIR) #3rd optional argument: extra module include directories
 
-	set(INCLUDE_DIR_EXPRESSIONS "")
-	foreach(MOD_DIR ${TARGET_MODULE_DIR} ${ARGN})
+	if(IS_ABSOLUTE "${TARGET_MODULE_DIR}")
+		# legacy full path, pass through unmodified
+		set(INCLUDE_DIRS ${TARGET_MODULE_DIR})
+	else()
 		# add both the build dir path and the installed path
-		list(APPEND INCLUDE_DIR_EXPRESSIONS $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${MOD_DIR}> $<INSTALL_INTERFACE:include/${MODULE_DIR_NAME}/${MOD_DIR}>)
+		set(INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR}> $<INSTALL_INTERFACE:include/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR}>)
+	endif()
+
+	# convert relative module paths being included to absolute
+	foreach(MOD_DIR ${ARGN})
+		if(IS_ABSOLUTE "${MOD_DIR}")
+			# pass through unmodified
+			list(APPEND INCLUDE_DIRS $<BUILD_INTERFACE:${MOD_DIR}>)
+		else()
+			# convert to absolute path for build
+			list(APPEND INCLUDE_DIRS $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${MOD_DIR}>)
+		endif()
 	endforeach()
 
-	#add all of the passed module directories
-	set(INCLUDE_DIRS ${TARGET_MODULE_DIR} ${ARGN})
-		
 	# get old include directories
 	get_property(PREV_INC_DIRS TARGET ${TARGETNAME} PROPERTY INCLUDE_DIRECTORIES)
 	get_property(PREV_INT_INC_DIRS TARGET ${TARGETNAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
@@ -40,9 +50,7 @@ function(config_module_dirs TARGETNAME TARGET_MODULE_DIR) #3rd optional argument
 
 	# combine the new module dirs with the rest of the include dirs
 	set_property(TARGET ${TARGETNAME} PROPERTY Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/${MODULE_DIR_NAME}/${TARGET_MODULE_DIR})
-	set_property(TARGET ${TARGETNAME} PROPERTY INCLUDE_DIRECTORIES ${INCLUDE_DIR_EXPRESSIONS} ${LEFTOVER_INC_DIRS})
-	set_property(TARGET ${TARGETNAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${INCLUDE_DIR_EXPRESSIONS} ${LEFTOVER_INT_INC_DIRS})
+	set_property(TARGET ${TARGETNAME} PROPERTY INCLUDE_DIRECTORIES ${INCLUDE_DIRS} ${LEFTOVER_INC_DIRS})
+	set_property(TARGET ${TARGETNAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${INCLUDE_DIRS} ${LEFTOVER_INT_INC_DIRS})
 	
 endfunction()
-	
-

--- a/quick-cmake/QUICKCudaConfig.cmake
+++ b/quick-cmake/QUICKCudaConfig.cmake
@@ -134,34 +134,13 @@ if(CUDA)
 		set(CUDA_DEVICE_CODE_FLAGS -Xptxas --disable-optimizer-constants)
 	endif()
 
-				
-	# --------------------------------------------------------------------
-	# import a couple of CUDA libraries used by amber tools
+	
+	if(NOT INSIDE_AMBER)
+		# --------------------------------------------------------------------
+		# import a couple of CUDA libraries used by amber tools
 
-	import_library(cublas "${CUDA_cublas_LIBRARY}")
-	import_library(cufft "${CUDA_cufft_LIBRARY}")
-	import_library(cusolver "${CUDA_cusolver_LIBRARY}")
-	import_library(curand "${CUDA_curand_LIBRARY}")
-	import_library(cusparse "${CUDA_cusparse_LIBRARY}")
- 	import_library(cudadevrt "${CUDA_cudadevrt_LIBRARY}")
-
- 	# --------------------------------------------------------------------
-	# Find the NVidia Management Library (used to detect GPUs)
-	# This library lives under the "stubs" subdirectory so we have to handle it specially.
-
-	find_library(CUDA_nvidia-ml_LIBRARY
-	    NAMES nvidia-ml
-	    PATHS "${CUDA_TOOLKIT_TARGET_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}"
-	    ENV CUDA_PATH
-	    ENV CUDA_LIB_PATH
-	    PATH_SUFFIXES lib64/stubs lib/stubs
-	    DOC "Path to the CUDA Nvidia Management Library")
-
-	if(NOT EXISTS "${CUDA_nvidia-ml_LIBRARY}")
-		message(WARNING "Cannot find the NVidia Management Library (libnvidia-ml) in your CUDA toolkit.  mdgx.cuda will not be built.") 
-	else()
- 		import_library(nvidia-ml "${CUDA_nvidia-ml_LIBRARY}")
- 	endif()
-
+		import_library(cublas "${CUDA_cublas_LIBRARY}")
+		import_library(cusolver "${CUDA_cusolver_LIBRARY}")
+	endif()
 
 endif()

--- a/quick-cmake/quick.rc
+++ b/quick-cmake/quick.rc
@@ -17,5 +17,5 @@ else
 fi
 
 export QUICK_INSTALL=$(cd "$(dirname "$this_script")/.."; pwd)
-export QUICK_BASIS="$QUICK_INSTALL/AmberTools/src/quick/basis"
+export QUICK_BASIS="$QUICK_INSTALL/basis"
 export PATH="$QUICK_INSTALL/bin":$PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,9 +109,9 @@ if(MPI)
 	set_property(TARGET libquick_mpi PROPERTY OUTPUT_NAME quick_mpi)
 
 	# change link libraries and mod dirs for MPI
-	remove_link_libraries(libquick_mpi xc octree)
-	target_link_libraries(libquick_mpi PRIVATE xc_mpi octree_mpi)
-	config_module_dirs(libquick_mpi quick/mpi libxc/mpi)
+	remove_link_libraries(libquick_mpi octree)
+	target_link_libraries(libquick_mpi PRIVATE octree_mpi)
+	config_module_dirs(libquick_mpi libxc/serial quick/mpi)
 
 
 	install_libraries(libquick_mpi EXPORT QUICK)
@@ -124,7 +124,7 @@ if(CUDA)
 
 	# change link libraries and mod dirs for CUDA
 	remove_link_libraries(libquick_cuda xc octree ${QUICK_BLAS} ${QUICK_LAPACK})
-	target_link_libraries(libquick_cuda PRIVATE xc_gpu xc_cuda octree_gpu quick_cuda_kernels ${CUDA_CUBLAS_LIBRARIES} ${CUDA_cusolver_LIBRARY})
+	target_link_libraries(libquick_cuda PRIVATE xc_gpu xc_cuda octree_gpu quick_cuda_kernels cublas cusolver)
 	config_module_dirs(libquick_cuda quick/cuda libxc/gpu)
 
 	install_libraries(libquick_cuda EXPORT QUICK)
@@ -135,8 +135,8 @@ if(MPI AND CUDA)
 	target_compile_definitions(libquick_mpi_cuda PRIVATE CUDA_MPIV)
 	set_property(TARGET libquick_mpi_cuda PROPERTY OUTPUT_NAME quick_mpi_cuda)
 
-	remove_link_libraries(libquick_mpi_cuda octree_mpi xc_mpi)
-	target_link_libraries(libquick_mpi_cuda PRIVATE xc_gpu xc_cuda octree_gpu quick_cuda_kernels_mpi ${CUDA_CUBLAS_LIBRARIES} ${CUDA_cusolver_LIBRARY})
+	remove_link_libraries(libquick_mpi_cuda octree_mpi xc)
+	target_link_libraries(libquick_mpi_cuda PRIVATE xc_gpu xc_cuda octree_gpu quick_cuda_kernels_mpi cublas cusolver)
 	config_module_dirs(libquick_mpi_cuda quick/mpi_cuda libxc/gpu)
 
 	install_libraries(libquick_mpi_cuda EXPORT QUICK)
@@ -180,11 +180,11 @@ if(MPI)
 	# change link libraries and mod dirs for MPI
 	remove_link_libraries(quick.MPI libquick)
 	target_link_libraries(quick.MPI libquick_mpi)
-	config_module_dirs(quick.MPI quick/mpi libxc/mpi)
+	config_module_dirs(quick.MPI quick/mpi libxc/serial)
 
 	remove_link_libraries(test-api.MPI libquick)
 	target_link_libraries(test-api.MPI libquick_mpi)
-	config_module_dirs(test-api.MPI quick/mpi libxc/mpi)
+	config_module_dirs(test-api.MPI quick/mpi libxc/serial)
 
 	install(TARGETS quick.MPI DESTINATION ${BINDIR} EXPORT QUICK)
 endif()

--- a/src/libxc/CMakeLists.txt
+++ b/src/libxc/CMakeLists.txt
@@ -138,12 +138,6 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 	target_compile_options(xc PRIVATE -Wno-maybe-uninitialized)
 endif()
 
-if(MPI)
-	make_mpi_version(xc xc_mpi LANGUAGES C)
-	target_compile_definitions(xc_mpi PUBLIC MPIV)
-	config_module_dirs(xc_mpi libxc/mpi)
-endif()
-
 if(CUDA)
 	# note: this is not a GPU implementation of libxc, it's just
 	# configured to call one.


### PR DESCRIPTION
This PR adds a couple things I missed in the original
- Fix optimization flags to use O2
- Fix permissions on installed tests
- Remove useless libxc_mpi target

It also fixes some incompatibilities with Amber.