### PR TITLE
fixed the scientific notation reading issue in input

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ set(QUICK_MODULES_SOURCES
 	quick_mfcc_module.f90 quick_params_module.f90 quick_pb_module.f90 
 	quick_scratch_module.f90 quick_all_module.f90 quick_scf_module.f90 
 	quick_gradient_module.f90 quick_api_module.f90 quick_api_test_module.f90
-	quick_cutoff_module.f90 quick_exception_module.f90)
+	quick_cutoff_module.f90 quick_exception_module.f90 quick_input_parser_module.f90)
 
 set(QUICK_SUBS_SOURCES Angles.f90 copyDMat.f90 copySym.f90 
 	degen.f90 denspt.f90 diag.f90 dipole.f90 

--- a/src/modules/Makefile
+++ b/src/modules/Makefile
@@ -26,7 +26,7 @@ include $(MAKEIN)
 FOR=$(FC) $(FFLAGS)
 
 modobj=$(objfolder)/quick_exception_module.o $(objfolder)/quick_files_module.o $(objfolder)/quick_mpi_module.o \
-		$(objfolder)/quick_constants_module.o $(objfolder)/quick_method_module.o \
+		$(objfolder)/quick_constants_module.o $(objfolder)/quick_input_parser_module.o $(objfolder)/quick_method_module.o \
 		$(objfolder)/quick_molspec_module.o $(objfolder)/quick_gaussian_class_module.o $(objfolder)/quick_size_module.o \
 		$(objfolder)/quick_amber_interface_module.o $(objfolder)/quick_basis_module.o $(objfolder)/quick_calculated_module.o \
 		$(objfolder)/quick_divcon_module.o $(objfolder)/quick_ecp_module.o $(objfolder)/quick_electrondensity_module.o \

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -42,7 +42,6 @@ module quick_input_parser_module
                 call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                 call quick_exit(OUTFILEHANDLE,1)
             endif         
-                 
         end subroutine read_float_keyword
 
         subroutine read_integer_keyword(line, keyword, val)

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -1,0 +1,83 @@
+#include "util.fh"
+module quick_input_parser_module
+
+    implicit none
+    
+    private
+    public :: read
+
+    interface read
+        module procedure read_integer_keyword
+        module procedure read_float_keyword
+        module procedure read_string_keyword
+    end interface read
+
+    contains
+
+        subroutine read_float_keyword(keywdline, keyword, val)
+            implicit none
+            character(len=*), intent(in) :: keywdline
+            character(len=*), intent(in) :: keyword
+            double precision :: val
+            integer :: i,j,ierror
+            
+            if(index(keywdline,keyword) /= 0) then
+                i = index(keywdline, trim(keyword)//trim('='))
+                if(i==0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
+                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
+                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val              
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif                
+            endif
+        end subroutine read_float_keyword
+
+        subroutine read_integer_keyword(keywdline, keyword, val)
+            implicit none
+            character(len=*), intent(in) :: keywdline
+            character(len=*), intent(in) :: keyword
+            integer :: val
+            integer :: i,j,ierror
+
+            if(index(keywdline,keyword) /= 0) then
+                i = index(keywdline, trim(keyword)//trim('='))
+                if(i==0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
+                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
+                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
+            endif
+        end subroutine read_integer_keyword    
+    
+        subroutine read_string_keyword(keywdline, keyword, val)
+            implicit none
+            character(len=*), intent(in) :: keywdline
+            character(len=*), intent(in) :: keyword
+            character(len=50) :: val
+            integer :: i,j,ierror
+
+            if(index(keywdline,keyword) /= 0) then
+                i = index(keywdline, trim(keyword)//trim('='))
+                if(i==0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
+                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
+                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
+            endif
+        end subroutine read_string_keyword
+
+end module quick_input_parser_module

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -16,7 +16,7 @@ module quick_input_parser_module
 
         subroutine checkformat(i,line,keyword)
             implicit none
-            integer, intent(inout) :: i
+            integer, intent(out) :: i
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
 

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -20,9 +20,9 @@ module quick_input_parser_module
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
 
-            i = index(line, trim(keyword)//trim('='))
+            i = index(line, trim(keyword)//'=')
             if(i==0) then
-                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                 call quick_exit(OUTFILEHANDLE,1)
             endif
         end subroutine checkformat
@@ -39,7 +39,7 @@ module quick_input_parser_module
             j = scan(line(i:len_trim(line)), ' ', .false.)
             read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
             if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                 call quick_exit(OUTFILEHANDLE,1)
             endif         
                  
@@ -56,7 +56,7 @@ module quick_input_parser_module
             j = scan(line(i:len_trim(line)), ' ', .false.)
             read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
             if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                 call quick_exit(OUTFILEHANDLE,1)
             endif
         end subroutine read_integer_keyword    
@@ -72,7 +72,7 @@ module quick_input_parser_module
             j = scan(line(i:len_trim(line)), ' ', .false.)
             read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
             if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                 call quick_exit(OUTFILEHANDLE,1)
             endif        
         end subroutine read_string_keyword

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -14,70 +14,67 @@ module quick_input_parser_module
 
     contains
 
-        subroutine read_float_keyword(keywdline, keyword, val)
+        subroutine checkformat(i,line,keyword)
             implicit none
-            character(len=*), intent(in) :: keywdline
+            integer, intent(inout) :: i
+            character(len=*), intent(in) :: line
+            character(len=*), intent(in) :: keyword
+
+            i = index(line, trim(keyword)//trim('='))
+            if(i==0) then
+                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif
+        end subroutine checkformat
+
+
+        subroutine read_float_keyword(line, keyword, val)
+            implicit none
+            character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
             double precision :: val
             integer :: i,j,ierror
             
-            if(index(keywdline,keyword) /= 0) then
-                i = index(keywdline, trim(keyword)//trim('='))
-                if(i==0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif
-                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
-                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val              
-                if(ierror/=0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif                
-            endif
+            call checkformat(i,line,keyword)
+            j = scan(line(i:len_trim(line)), ' ', .false.)
+            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
+            if(ierror/=0) then
+                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif         
+                 
         end subroutine read_float_keyword
 
-        subroutine read_integer_keyword(keywdline, keyword, val)
+        subroutine read_integer_keyword(line, keyword, val)
             implicit none
-            character(len=*), intent(in) :: keywdline
+            character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
             integer :: val
             integer :: i,j,ierror
 
-            if(index(keywdline,keyword) /= 0) then
-                i = index(keywdline, trim(keyword)//trim('='))
-                if(i==0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif
-                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
-                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
-                if(ierror/=0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif
+            call checkformat(i,line,keyword)
+            j = scan(line(i:len_trim(line)), ' ', .false.)
+            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
+            if(ierror/=0) then
+                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call quick_exit(OUTFILEHANDLE,1)
             endif
         end subroutine read_integer_keyword    
     
-        subroutine read_string_keyword(keywdline, keyword, val)
+        subroutine read_string_keyword(line, keyword, val)
             implicit none
-            character(len=*), intent(in) :: keywdline
+            character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
             character(len=50) :: val
             integer :: i,j,ierror
 
-            if(index(keywdline,keyword) /= 0) then
-                i = index(keywdline, trim(keyword)//trim('='))
-                if(i==0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif
-                j = scan(keywdline(i:len_trim(keywdline)), ' ', .false.)
-                read(keywdline(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
-                if(ierror/=0) then
-                    call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
-                    call quick_exit(OUTFILEHANDLE,1)
-                endif
-            endif
+            call checkformat(i,line,keyword)
+            j = scan(line(i:len_trim(line)), ' ', .false.)
+            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
+            if(ierror/=0) then
+                call PrtErr(OUTFILEHANDLE, "USE keyword=val format in input")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif        
         end subroutine read_string_keyword
 
 end module quick_input_parser_module

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -5,9 +5,11 @@
 !	Created by Yipu Miao on 2/18/11.
 !	Copyright 2011 University of Florida. All rights reserved.
 !
-
+#include "util.fh"
 module quick_method_module
     use quick_constants_module
+    use quick_input_parser_module  
+
     implicit none
 
     type quick_method_type
@@ -433,7 +435,7 @@ endif
             implicit none
             character(len=200) :: keyWD
             character(len=200) :: tempstring
-            integer :: itemp,rdinml,i,j
+            integer :: itemp,rdinml,i,j,ierror
             type (quick_method_type) self
 
             call upcase(keyWD,200)
@@ -514,9 +516,8 @@ endif
 
             if (index(keyWD,'ECP').ne.0)  then
                 self%ECP=.true.
-                i=index(keywd,'ECP=')
-                call rdword(keywd,i,j)
-                if (keywd(i+4:j).eq.'CUSTOM')  self%custECP=.true.
+                call read(keywd, 'ECP', tempstring)
+                if (tempstring .eq. 'CUSTOM') self%custECP=.true.
             endif
 
             if (index(keyWD,'USEDFT').ne.0) then
@@ -537,59 +538,57 @@ endif
             ! Density map
             ! JOHN FAVER 12/2008
             if (index(keywd,'DENSITYMAP') /= 0) then
-                i = index(keywd,'DENSITYMAP=',.false.)
-                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                read(keywd(i+10:i+j-2), *) self%gridspacing
+                call read(keywd, 'DENSITYMAP', self%gridspacing)
                 self%calcdens = .true.
             endif
-
+            
             ! Density lapmap
             if (index(keywd,'DENSITYLAPMAP') /= 0) then
-                i = index(keywd,'DENSITYLAPMAP=',.false.)
-                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                read(keywd(i+14:i+j-2), *) self%lapgridspacing
+                call read(keywd, 'DENSITYLAPMAP', self%lapgridspacing)
                 self%calcdenslap = .true.
             endif
 
             ! opt cycls
-            if (index(keywd,'OPTIMIZE=') /= 0) self%iopt = rdinml(keywd,'OPTIMIZE')
+            if (index(keywd,'OPTIMIZE') /= 0) then
+                call read(keywd, 'OPTIMIZE', self%iopt)
+            endif
 
             ! scf cycles
-            if (index(keywd,'SCF=') /= 0) self%iscf = rdinml(keywd,'SCF')
+            if (index(keywd,'SCF') /= 0) then
+                call read(keywd, 'SCF', self%iscf)
+            endif
 
             ! DM Max RMS
-            if (index(keywd,'DENSERMS=') /= 0) then
-                i = index(keywd,'DENSERMS=',.false.)
-                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                read(keywd(i+9:i+j-2), *) self%pmaxrms
+            if (index(keywd,'DENSERMS') /= 0) then
+                call read(keywd, 'DENSERMS', self%pmaxrms)
             endif
- 
-           ! 2e-cutoff
-            if (index(keywd,'CUTOFF=') /= 0) then
-                i = index(keywd,'CUTOFF=',.false.)
-                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                read(keywd(i+7:i+j-2), *) self%acutoff
+        
+            ! 2e-cutoff
+            if (index(keywd,'CUTOFF') /= 0) then
+                call read(keywd, 'CUTOFF', self%acutoff)
                 self%integralCutoff=self%acutoff !min(self%integralCutoff,self%acutoff)
                 self%primLimit=1E-20 !self%acutoff*0.001 !min(self%integralCutoff,self%acutoff)
                 self%gradCutoff=self%acutoff
             endif
 
             ! Max DIIS cycles
-            if (index(keywd,'MAXDIIS=') /= 0) self%maxdiisscf=rdinml(keywd,'MAXDIIS')
+            if (index(keywd,'MAXDIIS') /= 0) then
+                call read(keywd, 'MAXDIIS', self%maxdiisscf)
+            endif
 
             ! Delta DM Cycle Start
-            if (index(keywd,'NCYC=') /= 0) self%ncyc = rdinml(keywd,'NCYC')
+            if (index(keywd,'NCYC') /= 0) then
+                call read(keywd, 'NCYC', self%ncyc)
+            endif
 
             ! DM cutoff
-            if (index(keywd,'MATRIXZERO=') /= 0) then
-                i = index(keywd,'MATRIXZERO=',.false.)
-                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                read(keywd(i+11:i+j-2), *) self%DMCutoff
+            if (index(keywd,'MATRIXZERO') /= 0) then
+                call read(keywd,'MATRIXZERO', self%DMCutoff)
             endif
 
             ! Basis cutoff
             if (index(keywd,'BASISZERO=') /= 0) then
-                itemp=rdinml(keywd,'BASISZERO')
+                call read(keywd,'BASISZERO', itemp)
                 self%basisCufoff=10.d0**(-1.d0*itemp)
             endif
 

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -434,7 +434,6 @@ endif
             character(len=200) :: keyWD
             character(len=200) :: tempstring
             integer :: itemp,rdinml,i,j
-            double precision :: rdnml
             type (quick_method_type) self
 
             call upcase(keyWD,200)
@@ -538,25 +537,17 @@ endif
             ! Density map
             ! JOHN FAVER 12/2008
             if (index(keywd,'DENSITYMAP') /= 0) then
-                self%gridspacing = rdnml(keywd,'DENSITYMAP')
-                !In case that reading scientific notation like '1e-8' fails
-                if (self%gridspacing == 0) then
-                    i = index(keywd,'DENSITYMAP=',.false.)
-                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                    read(keywd(i+10:i+j-2), *) self%gridspacing
-                endif
+                i = index(keywd,'DENSITYMAP=',.false.)
+                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                read(keywd(i+10:i+j-2), *) self%gridspacing
                 self%calcdens = .true.
             endif
 
             ! Density lapmap
             if (index(keywd,'DENSITYLAPMAP') /= 0) then
-                self%lapgridspacing= rdnml(keywd,'DENSITYLAPMAP')
-                !In case that reading scientific notation like '1e-8' fails
-                if (self%lapgridspacing == 0) then
-                    i = index(keywd,'DENSITYLAPMAP=',.false.)
-                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                    read(keywd(i+14:i+j-2), *) self%lapgridspacing
-                endif
+                i = index(keywd,'DENSITYLAPMAP=',.false.)
+                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                read(keywd(i+14:i+j-2), *) self%lapgridspacing
                 self%calcdenslap = .true.
             endif
 
@@ -568,24 +559,16 @@ endif
 
             ! DM Max RMS
             if (index(keywd,'DENSERMS=') /= 0) then
-                self%pmaxrms = rdnml(keywd,'DENSERMS')
-                !In case that reading scientific notation like '1e-8' fails
-                if (self%pmaxrms == 0) then
-                    i = index(keywd,'DENSERMS=',.false.)
-                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                    read(keywd(i+9:i+j-2), *) self%pmaxrms
-                endif
+                i = index(keywd,'DENSERMS=',.false.)
+                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                read(keywd(i+9:i+j-2), *) self%pmaxrms
             endif
  
            ! 2e-cutoff
             if (index(keywd,'CUTOFF=') /= 0) then
-                self%acutoff = rdnml(keywd,'CUTOFF')
-                !In case that reading scientific notation like '1e-8' fails
-                if (self%acutoff == 0) then
-                    i = index(keywd,'CUTOFF=',.false.)
-                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                    read(keywd(i+7:i+j-2), *) self%acutoff
-                endif
+                i = index(keywd,'CUTOFF=',.false.)
+                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                read(keywd(i+7:i+j-2), *) self%acutoff
                 self%integralCutoff=self%acutoff !min(self%integralCutoff,self%acutoff)
                 self%primLimit=1E-20 !self%acutoff*0.001 !min(self%integralCutoff,self%acutoff)
                 self%gradCutoff=self%acutoff
@@ -599,13 +582,9 @@ endif
 
             ! DM cutoff
             if (index(keywd,'MATRIXZERO=') /= 0) then
-                self%DMCutoff = rdnml(keywd,'MATRIXZERO')
-                !In case that reading scientific notation like '1e-8' fails
-                if (self%DMCutoff == 0) then
-                    i = index(keywd,'MATRIXZERO=',.false.)
-                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
-                    read(keywd(i+11:i+j-2), *) self%DMCutoff
-                endif
+                i = index(keywd,'MATRIXZERO=',.false.)
+                j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                read(keywd(i+11:i+j-2), *) self%DMCutoff
             endif
 
             ! Basis cutoff

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -435,7 +435,7 @@ endif
             implicit none
             character(len=200) :: keyWD
             character(len=200) :: tempstring
-            integer :: itemp,rdinml,i,j,ierror
+            integer :: itemp,i,j
             type (quick_method_type) self
 
             call upcase(keyWD,200)

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -539,12 +539,24 @@ endif
             ! JOHN FAVER 12/2008
             if (index(keywd,'DENSITYMAP') /= 0) then
                 self%gridspacing = rdnml(keywd,'DENSITYMAP')
+                !In case that reading scientific notation like '1e-8' fails
+                if (self%gridspacing == 0) then
+                    i = index(keywd,'DENSITYMAP=',.false.)
+                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                    read(keywd(i+10:i+j-2), *) self%gridspacing
+                endif
                 self%calcdens = .true.
             endif
 
             ! Density lapmap
             if (index(keywd,'DENSITYLAPMAP') /= 0) then
                 self%lapgridspacing= rdnml(keywd,'DENSITYLAPMAP')
+                !In case that reading scientific notation like '1e-8' fails
+                if (self%lapgridspacing == 0) then
+                    i = index(keywd,'DENSITYLAPMAP=',.false.)
+                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                    read(keywd(i+14:i+j-2), *) self%lapgridspacing
+                endif
                 self%calcdenslap = .true.
             endif
 
@@ -555,11 +567,25 @@ endif
             if (index(keywd,'SCF=') /= 0) self%iscf = rdinml(keywd,'SCF')
 
             ! DM Max RMS
-            if (index(keywd,'DENSERMS=') /= 0) self%pmaxrms = rdnml(keywd,'DENSERMS')
-
-            ! 2e-cutoff
+            if (index(keywd,'DENSERMS=') /= 0) then
+                self%pmaxrms = rdnml(keywd,'DENSERMS')
+                !In case that reading scientific notation like '1e-8' fails
+                if (self%pmaxrms == 0) then
+                    i = index(keywd,'DENSERMS=',.false.)
+                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                    read(keywd(i+9:i+j-2), *) self%pmaxrms
+                endif
+            endif
+ 
+           ! 2e-cutoff
             if (index(keywd,'CUTOFF=') /= 0) then
                 self%acutoff = rdnml(keywd,'CUTOFF')
+                !In case that reading scientific notation like '1e-8' fails
+                if (self%acutoff == 0) then
+                    i = index(keywd,'CUTOFF=',.false.)
+                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                    read(keywd(i+7:i+j-2), *) self%acutoff
+                endif
                 self%integralCutoff=self%acutoff !min(self%integralCutoff,self%acutoff)
                 self%primLimit=1E-20 !self%acutoff*0.001 !min(self%integralCutoff,self%acutoff)
                 self%gradCutoff=self%acutoff
@@ -572,7 +598,15 @@ endif
             if (index(keywd,'NCYC=') /= 0) self%ncyc = rdinml(keywd,'NCYC')
 
             ! DM cutoff
-            if (index(keywd,'MATRIXZERO=') /= 0) self%DMCutoff = rdnml(keywd,'MAXTRIXZERO')
+            if (index(keywd,'MATRIXZERO=') /= 0) then
+                self%DMCutoff = rdnml(keywd,'MATRIXZERO')
+                !In case that reading scientific notation like '1e-8' fails
+                if (self%DMCutoff == 0) then
+                    i = index(keywd,'MATRIXZERO=',.false.)
+                    j = scan(keywd(i:len_trim(keywd)), ' ', .false.)
+                    read(keywd(i+11:i+j-2), *) self%DMCutoff
+                endif
+            endif
 
             ! Basis cutoff
             if (index(keywd,'BASISZERO=') /= 0) then


### PR DESCRIPTION
The scientific notation reading issues is fixed for all the keywords in the input file of which the value is supposed to be a double. The users are allowed to use the keywords like `cutoff=1e-9 denserms=1e-8`.