### PR TITLE
Few more CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,10 +149,10 @@ endif()
 if(INSIDE_AMBER)
 
 	# install data in basis dir
-	install(DIRECTORY basis DESTINATION AmberTools/src/quick)
+	install(DIRECTORY basis DESTINATION AmberTools/src/quick COMPONENT Data)
 
 	# install tests dir
-	install(DIRECTORY test DESTINATION AmberTools/src/quick)
+	install(DIRECTORY test DESTINATION AmberTools/src/quick COMPONENT Tests ${TESTS_EXCLUDE_OPTION})
 
 else()
 	# Standalone install

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ if(MPI)
 	# change link libraries and mod dirs for MPI
 	remove_link_libraries(libquick_mpi octree)
 	target_link_libraries(libquick_mpi PRIVATE octree_mpi)
-	config_module_dirs(libquick_mpi libxc/serial quick/mpi)
+	config_module_dirs(libquick_mpi quick/mpi libxc/serial)
 
 
 	install_libraries(libquick_mpi EXPORT QUICK)


### PR DESCRIPTION
With these changes, the build of QUICK sander should finally work reliably!  It turns out that since some other changes the MPI modules weren't getting put in the right folder.