### PR TITLE
Fix for issue #129

### DIFF
--- a/src/dft.f90
+++ b/src/dft.f90
@@ -2834,9 +2834,7 @@ subroutine gridformnew(iitype,distance,iiang)
          CALl LD0086(XANG,YANG,ZANG,WTANG,N)
          iiang=86
       endif
-   endif
-
-   if(quick_molspec%iattype(iitype).ge.3.and.quick_molspec%iattype(iitype).le.10)then
+    else if(quick_molspec%iattype(iitype).ge.3.and.quick_molspec%iattype(iitype).le.10)then
       if(distance.lt.lpartpara(1))then
          CALL LD0006(XANG,YANG,ZANG,WTANG,N)
          iiang=6
@@ -2853,9 +2851,7 @@ subroutine gridformnew(iitype,distance,iiang)
          CALl LD0086(XANG,YANG,ZANG,WTANG,N)
          iiang=86
       endif
-   endif
-
-   if(quick_molspec%iattype(iitype).ge.11.and.quick_molspec%iattype(iitype).le.18)then
+   else if(quick_molspec%iattype(iitype).ge.11.and.quick_molspec%iattype(iitype).le.18)then
       if(distance.lt.npartpara(1))then
          CALL LD0006(XANG,YANG,ZANG,WTANG,N)
          iiang=6
@@ -2872,9 +2868,7 @@ subroutine gridformnew(iitype,distance,iiang)
          CALl LD0086(XANG,YANG,ZANG,WTANG,N)
          iiang=86
       endif
-   endif
-
-   if(quick_molspec%iattype(iitype).eq.30)then
+   else 
       CALL LD0194(XANG,YANG,ZANG,WTANG,N)
       iiang=194
    endif


### PR DESCRIPTION
It turns out that the issue #129 is caused by a sloppy conditional statement in DFT grid generation code. This has been fixed. We have to add more dft grids somewhere down the line. SG1 is not good for Alkali, Alkaline earth and halogens. See the following b3lyp/def2-svp energy comparison of different compounds (covers all elements except HI in current scope) between QUICK and a reference code.

```
AlH3 ref: -243.781735361, quick: -243.781908364 diff: 0.00017300300001465985
BeH2 ref: -15.8603827816, quick: -15.860404278 diff: 2.1496400000486915e-05
BH3 ref: -26.5734175368, quick: -26.573418543 diff: 1.006199997988233e-06
CaCl2 ref: -1593.12904130, quick: -1593.129022946 diff: -1.835399984884134e-05
CH4 ref: -40.4887262332, quick: -40.488727144 diff: 9.108000043056563e-07
H2O ref: -76.3417420591, quick: -76.341742540 diff: 4.808999989336371e-07
HBr ref: -2574.38724809, quick: -2574.385829155 diff: -0.0014189349999469414
KCl ref: -1059.99125206, quick: -1059.990853939 diff: -0.00039812099998925987
LiF ref: -107.320962139, quick: -107.320819934 diff: -0.00014220500000305947
MgO ref: -275.104031960, quick: -275.104224198 diff: 0.00019223800001100244
NaCl ref: -622.390032414, quick: -622.389903171 diff: -0.0001292429999466549
NH4 ref: -56.8542439306, quick: -56.854245606 diff: 1.675400000067384e-06
PH3 ref: -343.058460502, quick: -343.058482771 diff: 2.2268999998686922e-05
SiH4 ref: -291.435053152, quick: -291.435208628 diff: 0.0001554759999748967
SO2 ref: -548.311866835, quick: -548.311838296 diff: -2.853900002719456e-05
```
