### PR TITLE
new input parser

### DIFF
--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -14,18 +14,48 @@ module quick_input_parser_module
 
     contains
 
-        subroutine checkformat(i,line,keyword)
+        subroutine trimSpace(i,j,line,keyword,found)
             implicit none
-            integer, intent(out) :: i
+            integer, intent(out) :: i,j
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
+            logical, intent(out) :: found
 
-            i = index(line, trim(keyword)//'=')
-            if(i==0) then
-                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
-                call quick_exit(OUTFILEHANDLE,1)
+            print *, "keyword is ", keyword
+    
+            !first, go to the right to the end of the keyword
+            i = index(line, trim(keyword))+len_trim(keyword)
+            print *, "line(i:i+4) is", line(i:i+4)
+        
+            !ignore all spaces left to the equal sign
+            do while(line(i:i)==' ')
+                i=i+1
+            end do
+
+            !if equal sign not found, return
+            if(line(i:i) /= '=') then
+                print *, "didn't find assigned value"
+                found = .false.
+                return
             endif
-        end subroutine checkformat
+
+            !ignore all spaces right to the equal sign
+            i=i+1
+            do while(line(i:i)==' ')
+                i=i+1
+            end do
+
+            !read value
+            !print *, "for j, line(i:len_trim(line)) is",line(i:len_trim(line))
+            j = scan(line(i:len_trim(line)), ' ', .false.)  
+            !if hit the end of the line so no space any more on the right
+            if(j==0) then
+                j = len_trim(line)
+            endif
+            
+            found = .true.
+            
+        end subroutine trimSpace
 
 
         subroutine read_float_keyword(line, keyword, val)
@@ -34,29 +64,34 @@ module quick_input_parser_module
             character(len=*), intent(in) :: keyword
             double precision :: val
             integer :: i,j,ierror
-            
-            call checkformat(i,line,keyword)
-            j = scan(line(i:len_trim(line)), ' ', .false.)
-            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
-            if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
-                call quick_exit(OUTFILEHANDLE,1)
+            logical :: found            
+
+            call trimSpace(i,j,line,keyword,found)
+            if(found) then
+                read(line(i:i+j-2),*, iostat=ierror) val
+                print *, "val is ", val
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
             endif         
         end subroutine read_float_keyword
 
         subroutine read_integer_keyword(line, keyword, val)
             implicit none
-            character(len=*), intent(in) :: line
+            character(len=*),intent(in) :: line
             character(len=*), intent(in) :: keyword
             integer :: val
             integer :: i,j,ierror
-
-            call checkformat(i,line,keyword)
-            j = scan(line(i:len_trim(line)), ' ', .false.)
-            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
-            if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
-                call quick_exit(OUTFILEHANDLE,1)
+            logical :: found 
+          
+            call trimSpace(i,j,line,keyword,found)
+            if(found) then
+                read(line(i:i+j-2),*, iostat=ierror) val
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
             endif
         end subroutine read_integer_keyword    
     
@@ -66,13 +101,15 @@ module quick_input_parser_module
             character(len=*), intent(in) :: keyword
             character(len=50) :: val
             integer :: i,j,ierror
+            logical :: found            
 
-            call checkformat(i,line,keyword)
-            j = scan(line(i:len_trim(line)), ' ', .false.)
-            read(line(i+len_trim(keyword)+1:i+j-2),*, iostat=ierror) val
-            if(ierror/=0) then
-                call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
-                call quick_exit(OUTFILEHANDLE,1)
+            call trimSpace(i,j,line,keyword,found)
+            if(found) then
+                read(line(i:i+j-2),*, iostat=ierror) val
+                if(ierror/=0) then
+                    call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
+                    call quick_exit(OUTFILEHANDLE,1)
+                endif
             endif        
         end subroutine read_string_keyword
 

--- a/src/modules/quick_input_parser_module.f90
+++ b/src/modules/quick_input_parser_module.f90
@@ -20,33 +20,28 @@ module quick_input_parser_module
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
             logical, intent(out) :: found
-
-            print *, "keyword is ", keyword
     
             !first, go to the right to the end of the keyword
             i = index(line, trim(keyword))+len_trim(keyword)
-            print *, "line(i:i+4) is", line(i:i+4)
         
             !ignore all spaces left to the equal sign
-            do while(line(i:i)==' ')
+            do while(line(i:i)==' ' .or. line(i:i)==achar(9))
                 i=i+1
             end do
 
             !if equal sign not found, return
             if(line(i:i) /= '=') then
-                print *, "didn't find assigned value"
                 found = .false.
                 return
             endif
 
             !ignore all spaces right to the equal sign
             i=i+1
-            do while(line(i:i)==' ')
+            do while(line(i:i)==' ' .or. line(i:i)==achar(9))
                 i=i+1
             end do
 
             !read value
-            !print *, "for j, line(i:len_trim(line)) is",line(i:len_trim(line))
             j = scan(line(i:len_trim(line)), ' ', .false.)  
             !if hit the end of the line so no space any more on the right
             if(j==0) then
@@ -58,18 +53,30 @@ module quick_input_parser_module
         end subroutine trimSpace
 
 
-        subroutine read_float_keyword(line, keyword, val)
+        subroutine read_float_keyword(line, keyword, val, required)
             implicit none
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
-            double precision :: val
+            logical, intent(in), optional :: required
+            double precision, intent(inout) :: val
             integer :: i,j,ierror
             logical :: found            
+            logical :: reqdef !default value of required
+            
+            reqdef = .true.
+            if(present(required)) then
+                reqdef = required
+            endif
 
             call trimSpace(i,j,line,keyword,found)
+
+            if(reqdef .and. .not. found) then
+                call PrtErr(OUTFILEHANDLE, "Keyword "//trim(keyword)//" needs an input value.")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif
+
             if(found) then
                 read(line(i:i+j-2),*, iostat=ierror) val
-                print *, "val is ", val
                 if(ierror/=0) then
                     call PrtErr(OUTFILEHANDLE, "Error with keyword "//trim(keyword)//" encountered.")
                     call quick_exit(OUTFILEHANDLE,1)
@@ -77,15 +84,28 @@ module quick_input_parser_module
             endif         
         end subroutine read_float_keyword
 
-        subroutine read_integer_keyword(line, keyword, val)
+        subroutine read_integer_keyword(line, keyword, val, required)
             implicit none
             character(len=*),intent(in) :: line
             character(len=*), intent(in) :: keyword
-            integer :: val
+            logical, intent(in), optional :: required
+            integer, intent(inout) :: val
             integer :: i,j,ierror
             logical :: found 
-          
+            logical :: reqdef !default value of required          
+
+            reqdef = .true.
+            if(present(required)) then
+                reqdef=required
+            endif
+    
             call trimSpace(i,j,line,keyword,found)
+
+            if(reqdef .and. .not. found) then
+                call PrtErr(OUTFILEHANDLE, "Keyword "//trim(keyword)//" needs an input value.")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif 
+
             if(found) then
                 read(line(i:i+j-2),*, iostat=ierror) val
                 if(ierror/=0) then
@@ -95,15 +115,28 @@ module quick_input_parser_module
             endif
         end subroutine read_integer_keyword    
     
-        subroutine read_string_keyword(line, keyword, val)
+        subroutine read_string_keyword(line, keyword, val, required)
             implicit none
             character(len=*), intent(in) :: line
             character(len=*), intent(in) :: keyword
-            character(len=50) :: val
+            logical, intent(in), optional :: required
+            character(len=50), intent(inout) :: val
             integer :: i,j,ierror
-            logical :: found            
+            logical :: found   
+            logical :: reqdef !default value of required         
+
+            reqdef = .true.
+            if(present(required)) then
+                reqdef=required
+            endif
 
             call trimSpace(i,j,line,keyword,found)
+            
+            if(reqdef .and. .not. found) then
+                call PrtErr(OUTFILEHANDLE, "Keyword "//trim(keyword)//" needs an input value.")
+                call quick_exit(OUTFILEHANDLE,1)
+            endif
+
             if(found) then
                 read(line(i:i+j-2),*, iostat=ierror) val
                 if(ierror/=0) then

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -550,7 +550,7 @@ endif
 
             ! opt cycls
             if (index(keywd,'OPTIMIZE') /= 0) then
-                call read(keywd, 'OPTIMIZE', self%iopt)
+                call read(keywd, 'OPTIMIZE', self%iopt, .false.)
             endif
 
             ! scf cycles


### PR DESCRIPTION
A new input parser is implemented. It allows the users to have spaces on the two sides of the equal sign which maps the keyword to the value like `OPTIMIZE = 5` as in https://github.com/merzlab/QUICK/issues/140. It can also parse the keyword at the end of the input line with no trailing spaces (as required in https://github.com/merzlab/QUICK/issues/142).
