### PR TITLE
Update CMake build system compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT INSIDE_AMBER)
 	set(BUNDLED_3RDPARTY_TOOLS blas lapack)
 	include(3rdPartyTools)
 	
-	include(CompilerFlags)
+	include(QUICKCompilerFlags)
 
 	#CPack setup
 	# --------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9.0) # version 3.9.0 needed for FindMPI and FindOpenMP versions which provide imported targets
 
-project(quick LANGUAGES NONE VERSION 20.03)
+project(quick LANGUAGES NONE VERSION 21.03)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quick-cmake)
 if(NOT INSIDE_AMBER)
@@ -44,15 +44,7 @@ option(NOF "Disables the compilation of QUICK's time consuming f functions in th
 set_property(DIRECTORY . PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG>)
 
 
-if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-
-	# QUICK needs to be built with -O2 not Amber's default of -O3
-	if(OPTIMIZE)
-		list(APPEND OPT_CFLAGS -O2)
-		set(OPT_CFLAGS_SPC "${OPT_CFLAGS_SPC} -O2")
-	endif()
-
-elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
 	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -traceback")
 endif()
 
@@ -61,20 +53,17 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
 	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
 	add_definitions(-DGNU)
 
-	if(OPTIMIZE)
-		list(APPEND OPT_FFLAGS -O2)
-		set(OPT_FFLAGS_SPC "${OPT_FFLAGS_SPC} -O2")
-	endif()
-
 	if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
 		set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
 	endif()
 
 endif()
+
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
 	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -diag-disable 8291")
 	set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -traceback")
 endif()
+
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI")
 	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp") # force use of preprocessor for Fortran files with the "wrong" file extension
 endif()

--- a/cmake/AmberCompilerConfig.cmake
+++ b/cmake/AmberCompilerConfig.cmake
@@ -10,11 +10,8 @@ set(COMPILER_HELP "
                  -----------------------------------------------------------------------
   COMPILER value | C executable | C++ executable | Fortran executable | tested versions
   --------------------------------------------------------------------------------------
-      GNU        |     gcc      |      g++       |     gfortran       | 4.4.7, 4.8.4 +
-      INTEL      |     icc      |      icpc      |     ifort          | 12 - 17
-      PGI        |     pgcc     |      pgc++     |     pgf90          | 14.9, 15.4, 16.5
-      CLANG      |     clang    |      clang++   |     gfortran       | 
-      CRAY       |     cc       |      CC        |     ftn            | 8.4.6*
+      GNU        |     gcc      |      g++       |     gfortran       | 4.8.5 +
+      INTEL      |     icc      |      icpc      |     ifort          | 19
   --------------------------------------------------------------------------------------
       AUTO       |   <uses the default CMake-chosen compilers>
       MANUAL     |   <uses the CC, CXX, and FC environment variables, or the 

--- a/cmake/CompilationOptions.cmake
+++ b/cmake/CompilationOptions.cmake
@@ -39,6 +39,7 @@ set(BUILD_SHARED_LIBS ${SHARED})
 # So, we use CMAKE_<LANG>_FLAGS_DEBUG for per-config debugging flags, but use a separate optimization switch.
 option(OPTIMIZE "Whether to build code with compiler flags for optimization." TRUE)
 
+option(WARNINGS "Enable warnings." FALSE)
 option(UNUSED_WARNINGS "Enable warnings about unused variables.  Really clutters up the build output." FALSE)
 option(UNINITIALIZED_WARNINGS "Enable warnings about uninitialized variables.  Kind of clutters up the build output, but these need to be fixed." TRUE)
 

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -261,11 +261,11 @@ endif()
 #---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
-	set(CMAKE_C_FLAGS_DEBUG "-g -debug all")
-	
-	set(OPT_CFLAGS -ip -O3)
+    set(CMAKE_C_FLAGS_DEBUG "-g -debug all")
+    
+    set(OPT_CFLAGS -ip -O2)
 		
-	#  How flags get set for optimization depend on whether we have a MIC processor,
+    #  How flags get set for optimization depend on whether we have a MIC processor,
     #  the version of Intel compiler we have, and whether we are cross-compiling
     #  for multiple versions of SSE support.  The following coordinates all of this.
     #  This was done assuming that MIC and SSE are mutually exclusive and that we want
@@ -273,75 +273,71 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
     #  SSE_TYPES specification needs to be given in place of xHost not in addition to.
     #  This observed behavior is not what is reported by the Intel man pages. BPK
 	
-	if(SSE)
-		# BPK removed section that modified O1 or O2 to be O3 if optimize was set to yes.
+    if(SSE)
+	# BPK removed section that modified O1 or O2 to be O3 if optimize was set to yes.
       	# We already begin with the O3 setting so it wasn't needed.
         # For both coptflags and foptflags, use the appropriate settings
         # for the sse flags (compiler version dependent).
         if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER 11 OR ${CMAKE_C_COMPILER_VERSION} VERSION_EQUAL 11)
-			if(NOT "${SSE_TYPES}" STREQUAL "")
-				list(APPEND OPT_CFLAGS "-ax${SSE_TYPES}")
-			else()
-				list(APPEND OPT_CFLAGS -xHost)
-			endif()
-		else()
-			list(APPEND OPT_CFLAGS -axSTPW)
-		endif()
-		
+	    if(NOT "${SSE_TYPES}" STREQUAL "")
+		list(APPEND OPT_CFLAGS "-ax${SSE_TYPES}")
+	    else()
+		list(APPEND OPT_CFLAGS -xHost)
+	    endif()
+	else()
+	    list(APPEND OPT_CFLAGS -axSTPW)
 	endif()
+	
+    endif()
 endif()
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
-
-	if(WIN32)
-		add_flags(Fortran /D_CRT_SECURE_NO_WARNINGS)
+    
+    if(WIN32)
+	add_flags(Fortran /D_CRT_SECURE_NO_WARNINGS)
 	
-		set(OPT_FFLAGS "/Ox")
-		
-		set(CMAKE_Fortran_FLAGS_DEBUG "/Zi")
-	else()
-		set(CMAKE_Fortran_FLAGS_DEBUG "-g -debug all")
-		
-		set(OPT_FFLAGS -ip -O3)
-		
-		if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_EQUAL 18)
-			message(WARNING "Significant test failures were experienced with 2018 versions of Intel compilers!  Workarounds for these known problems have been implemented.  \
-However, we do not recommend building Amber with icc version 18. Versions 19, 17, and 16 are much more stable.")
+	set(OPT_FFLAGS "/Ox")
+	
+	set(CMAKE_Fortran_FLAGS_DEBUG "/Zi")
+    else()
+	set(CMAKE_Fortran_FLAGS_DEBUG "-g -debug all")
+	
+	set(OPT_FFLAGS -ip -O2)
+	
+	if(SSE)
+	    
+	    if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER 11 OR ${CMAKE_Fortran_COMPILER_VERSION} VERSION_EQUAL 11)
+		if(NOT "${SSE_TYPES}" STREQUAL "")
+		    list(APPEND OPT_FFLAGS "-ax${SSE_TYPES}")
+		else()
+		    list(APPEND OPT_FFLAGS -xHost)
 		endif()
-			
-		if(SSE)
-
-			if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER 11 OR ${CMAKE_Fortran_COMPILER_VERSION} VERSION_EQUAL 11)
-				if(NOT "${SSE_TYPES}" STREQUAL "")
-					list(APPEND OPT_FFLAGS "-ax${SSE_TYPES}")
-				else()
-					list(APPEND OPT_FFLAGS -xHost)
-				endif()
-			else()
-				list(APPEND OPT_FFLAGS -axSTPW)
-			endif()
-		endif()
-		
-		
-		# warning flags
-		add_flags(Fortran "-warn all" "-warn nounused")
-		
-		option(IFORT_CHECK_INTERFACES "If enabled and Intel Fortran is in use, then ifort will check that types passed to functions are the correct ones, and produce warnings or errors for mismatches." FALSE)
-		
-		if(NOT IFORT_CHECK_INTERFACES)
-			
-			# disable errors from type mismatches
-			add_flags(Fortran -warn nointerfaces)
-		endif()
-			
-		
+	    else()
+		list(APPEND OPT_FFLAGS -axSTPW)
+	    endif()
 	endif()
+		
+		
+	# warning flags
+	if(WARNINGS)
+	    add_flags(Fortran "-warn all" "-warn nounused")
+	    
+	    option(IFORT_CHECK_INTERFACES "If enabled and Intel Fortran is in use, then ifort will check that types passed to functions are the correct ones, and produce warnings or errors for mismatches." FALSE)
+		
+	    if(NOT IFORT_CHECK_INTERFACES)
+			
+		# disable errors from type mismatches
+		add_flags(Fortran -warn nointerfaces)
+	    endif()
+	endif()		
+		
+    endif()
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-	set(CMAKE_CXX_FLAGS_DEBUG "-g -debug all")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -debug all")
 	
-	set(OPT_CXXFLAGS -O3)
+    set(OPT_CXXFLAGS -ip -O2)
 endif()
 
 # PGI

--- a/cmake/QUICKCompilerFlags.cmake
+++ b/cmake/QUICKCompilerFlags.cmake
@@ -1,0 +1,209 @@
+# File which figures out the compiler flags to use based on the vendor and version of each compiler
+# Note: must be included after OpenMPConfig, MPIConfig, and PythonConfig
+
+#-------------------------------------------------------------------------------
+#  Handle CMake fortran compiler version issue
+#  See https://cmake.org/Bug/view.php?id=15372
+#-------------------------------------------------------------------------------
+	
+if(CMAKE_Fortran_COMPILER_LOADED AND "${CMAKE_Fortran_COMPILER_VERSION}" STREQUAL "")
+
+	set(CMAKE_Fortran_COMPILER_VERSION ${CMAKE_C_COMPILER_VERSION} CACHE STRING "Fortran compiler version.  May not be autodetected correctly on older CMake versions, fix this if it's wrong." FORCE)
+	message(FATAL_ERROR "Your CMake is too old to properly detect the Fortran compiler version.  It is assumed to be the same as your C compiler version, ${CMAKE_C_COMPILER_VERSION}. If this is not correct, pass -DCMAKE_Fortran_COMPILER_VERSION=<correct version> to cmake.  If it is correct,just run the configuration again.")
+	
+endif()
+	
+
+# create linker flags
+# On Windows undefined symbols in shared libraries produce errors.
+# This makes them do that on Linux too.
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${NO_UNDEFINED_FLAG}")
+
+
+
+#-------------------------------------------------------------------------------
+#  Set default flags
+#-------------------------------------------------------------------------------
+
+set(NO_OPT_FFLAGS -O0)
+set(NO_OPT_CFLAGS -O0)
+set(NO_OPT_CXXFLAGS -O0)
+
+set(CMAKE_C_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_Fortran_FLAGS_DEBUG "-g")
+
+#blank cmake's default optimization flags, we can't use these because not everything should be built optimized.
+set(CMAKE_C_FLAGS_RELEASE "")
+set(CMAKE_CXX_FLAGS_RELEASE "")
+set(CMAKE_Fortran_FLAGS_RELEASE "")
+
+#a macro to make things a little cleaner
+#NOTE: we can't use add_compile_options because that will apply to all languages
+macro(add_flags LANGUAGE) # FLAGS...
+	foreach(FLAG ${ARGN})
+		set(CMAKE_${LANGUAGE}_FLAGS "${CMAKE_${LANGUAGE}_FLAGS} ${FLAG}")
+	endforeach()
+endmacro(add_flags)
+
+
+#gnu
+#-------------------------------------------------------------------------------
+
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+
+    set(OPT_CFLAGS -O2 -mtune=native)
+
+    if (WARNINGS)
+	add_flags(C -Wall -Wno-unused-function -Wno-unknown-pragmas)
+    
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(C -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+    
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(C -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+    
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    
+    set(OPT_CXXFLAGS -O2 -mtune=native)
+
+    if (WARNINGS)
+	add_flags(CXX -Wall -Wno-unused-function -Wno-unknown-pragmas)
+    
+	# Kill it!  Kill it with fire!
+	check_cxx_compiler_flag(-Wno-unused-local-typedefs SUPPORTS_WNO_UNUSED_LOCAL_TYPEDEFS)
+
+	if(SUPPORTS_WNO_UNUSED_LOCAL_TYPEDEFS)
+	    add_flags(CXX -Wno-unused-local-typedefs)
+	endif()
+	
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(CXX -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+	
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(CXX -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+	
+endif()
+
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+
+    set(OPT_FFLAGS -O2 -mtune=native)
+
+    add_flags(Fortran -ffree-line-length-none)
+
+    if (WARNINGS)
+	add_flags(Fortran -Wall -Wno-tabs -Wno-unused-function -ffree-line-length-none)
+    
+	if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER 4.1)	
+	    add_flags(Fortran -Wno-unused-dummy-argument)
+	endif()	
+    
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(Fortran -Wno-unused-variable)
+	endif()
+		
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(Fortran -Wno-maybe-uninitialized)
+	endif()	
+    endif()
+		
+endif()
+
+#intel
+#-------------------------------------------------------------------------------
+
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+
+    set(CMAKE_C_FLAGS_DEBUG "-g -debug all")
+    
+    set(OPT_CFLAGS -ip -O2 -xHost)
+		
+endif()
+
+if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
+    
+    set(CMAKE_Fortran_FLAGS_DEBUG "-g -debug all")
+	
+    set(OPT_FFLAGS -ip -O2 -xHost)
+	
+    if(WARNINGS)
+	add_flags(Fortran "-warn all" "-warn nounused")
+	    
+	option(IFORT_CHECK_INTERFACES "If enabled and Intel Fortran is in use, then ifort will check that types passed to functions are the correct ones, and produce warnings or errors for mismatches." FALSE)
+		
+	if(NOT IFORT_CHECK_INTERFACES)
+			
+	    # disable errors from type mismatches
+	    add_flags(Fortran -warn nointerfaces)
+	endif()
+    endif()		
+		
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -debug all")
+	
+    set(OPT_CXXFLAGS -ip -O2 -xHost)
+
+endif()
+
+#-------------------------------------------------------------------------------
+#  Add some non-compiler-dependent items
+#-------------------------------------------------------------------------------
+if(LARGE_FILE_SUPPORT)
+	if(CMAKE_SIZEOF_VOID_P LESS 8)
+		add_definitions(-D_FILE_OFFSET_BITS=64)
+	endif()
+endif()
+
+check_symbol_exists(mkstemp stdlib.h HAVE_MKSTEMP)
+if(HAVE_MKSTEMP)
+    add_definitions(-DUSE_MKSTEMP)
+endif()
+
+#-------------------------------------------------------------------------------
+#  finalize the flags
+#-------------------------------------------------------------------------------
+
+#put the opt cxxflags into the CUDA flags
+foreach(FLAG ${OPT_CXXFLAGS})
+	list(APPEND HOST_NVCC_FLAGS ${FLAG})
+endforeach()
+
+
+# disable optimization flags if optimization is disabled
+if(NOT OPTIMIZE)
+	set(OPT_FFLAGS ${NO_OPT_FFLAGS})
+	set(OPT_CFLAGS ${NO_OPT_CFLAGS})
+	set(OPT_CXXFLAGS ${NO_OPT_CXXFLAGS})
+endif()
+
+#create space-separated versions of each flag set for use in PROPERTY COMPILE_FLAGS
+list_to_space_separated(OPT_FFLAGS_SPC ${OPT_FFLAGS})
+list_to_space_separated(OPT_CFLAGS_SPC ${OPT_CFLAGS})
+list_to_space_separated(OPT_CXXFLAGS_SPC ${OPT_CXXFLAGS})
+
+list_to_space_separated(NO_OPT_FFLAGS_SPC ${NO_OPT_FFLAGS})
+list_to_space_separated(NO_OPT_CFLAGS_SPC ${NO_OPT_CFLAGS})
+list_to_space_separated(NO_OPT_CXXFLAGS_SPC ${NO_OPT_CXXFLAGS})
+
+
+# When a library links to an imported library with interface include directories, CMake uses the -isystem flag to include  those directories
+# Unfortunately, this seems to completely not work with Fortran, so we disable it.
+set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE) 
+
+# Another issue is that CMake removes certain directories such as /usr/include if they
+# are manually applied to the search path, since apparently manually including them
+# can break some C/C++ toolchains (https://gitlab.kitware.com/cmake/cmake/issues/17966).
+# However it also does this for Fortran and that breaks the ability to include Fortran
+# modules found in system directories like /usr/include.
+unset(CMAKE_Fortran_IMPLICIT_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
Update defaults
- disable warnings so users don't get shocked
- warnings can be enabled with -DWARNINGS=TRUE
- downgrade frome -O3 to -O2 so we won't have nasty surprises with the release on untested platforms
- remove duplicate -O2 flag
- update version number to 21.03
- remove PGI, CRAY, CLANG as these have not been tested or are not working