### PR TITLE
Update CMake build system compiler flags - attempt 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9.0) # version 3.9.0 needed for FindMPI and FindOpenMP versions which provide imported targets
 
-project(quick LANGUAGES NONE VERSION 20.03)
+project(quick LANGUAGES NONE VERSION 21.03)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quick-cmake)
 if(NOT INSIDE_AMBER)
@@ -53,6 +53,10 @@ option(WARNINGS "Enable warnings." FALSE)
 set(NO_OPT_FFLAGS -O0)
 set(NO_OPT_CFLAGS -O0)
 set(NO_OPT_CXXFLAGS -O0)
+
+set(CMAKE_C_FLAGS "")
+set(CMAKE_CXX_FLAGS "")
+set(CMAKE_Fortran_FLAGS "")
 
 # GNU
 # --------------------------------------------------------------------
@@ -171,11 +175,11 @@ endif()
 
 # PGI, CRAY, CLANG: NOT SUPPORTED
 # --------------------------------------------------------------------
-if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI")
+if(${COMPILER} STREQUAL PGI)
     message(FATAL_ERROR "PGI compiler not supported by QUICK.")
-elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "CRAY")
+elseif(${COMPILER} STREQUAL CRAY)
     message(FATAL_ERROR "CRAY compiler not supported by QUICK.")
-elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "CLANG")
+elseif(${COMPILER} STREQUAL CLANG)
     message(FATAL_ERROR "CLANG compiler not supported by QUICK.")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,47 +37,165 @@ endif()
 
 option(NOF "Disables the compilation of QUICK's time consuming f functions in the ERI code of cuda version. Not recommended for production." FALSE)
 
-# C/Fortran compiler flags
+# Compiler flags
+# These should really go into cmake/CompilerFlags.cmake but with the
+# current setup in Amber the Amber compilation flags will take
+# precedence so we need to overwrite those here until we have a fully
+# independent build system for Quick and integrate Quick in Amber
+# as ExternalProject
 # --------------------------------------------------------------------
 
 # add -DDEBUG in debug configuration
 set_property(DIRECTORY . PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG>)
 
+option(WARNINGS "Enable warnings." FALSE)
 
+set(NO_OPT_FFLAGS -O0)
+set(NO_OPT_CFLAGS -O0)
+set(NO_OPT_CXXFLAGS -O0)
+
+# GNU
+# --------------------------------------------------------------------
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 
-	# QUICK needs to be built with -O2 not Amber's default of -O3
-	if(OPTIMIZE)
-		list(APPEND OPT_CFLAGS -O2)
-		set(OPT_CFLAGS_SPC "${OPT_CFLAGS_SPC} -O2")
-	endif()
+    set(OPT_CFLAGS -O2 -mtune=native)
 
-elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
-	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -traceback")
+    if (WARNINGS)
+	add_flags(C -Wall -Wno-unused-function -Wno-unknown-pragmas)
+    
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(C -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+    
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(C -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+    
 endif()
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    
+    set(OPT_CXXFLAGS -O2 -mtune=native)
+
+    if (WARNINGS)
+	add_flags(CXX -Wall -Wno-unused-function -Wno-unknown-pragmas)
+    
+	# Kill it!  Kill it with fire!
+	check_cxx_compiler_flag(-Wno-unused-local-typedefs SUPPORTS_WNO_UNUSED_LOCAL_TYPEDEFS)
+
+	if(SUPPORTS_WNO_UNUSED_LOCAL_TYPEDEFS)
+	    add_flags(CXX -Wno-unused-local-typedefs)
+	endif()
+	
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(CXX -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+	
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(CXX -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+
+endif()
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
-	add_definitions(-DGNU)
 
-	if(OPTIMIZE)
-		list(APPEND OPT_FFLAGS -O2)
-		set(OPT_FFLAGS_SPC "${OPT_FFLAGS_SPC} -O2")
-	endif()
+    set(OPT_FFLAGS -O2 -mtune=native)
 
-	if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-		set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+    add_flags(Fortran -ffree-line-length-none)
+
+    if (WARNINGS)
+	add_flags(Fortran -Wall -Wno-tabs -Wno-unused-function -ffree-line-length-none -Wno-unused-dummy-argument)
+    
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(Fortran -Wno-unused-variable)
 	endif()
+		
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(Fortran -Wno-maybe-uninitialized)
+	endif()	
+    endif()
+
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp")
+
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+    endif()
+
+    add_definitions(-DGNU)
 
 endif()
+
+
+# Intel
+# --------------------------------------------------------------------
+
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel")
+
+    set(CMAKE_C_FLAGS_DEBUG "-g -debug all -traceback")
+    
+    set(OPT_CFLAGS -ip -O2 -xHost)
+		
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+
+    set(CMAKE_CXX_FLAGS_DEBUG "-g -debug all -traceback")
+	
+    set(OPT_CXXFLAGS -ip -O2 -xHost)
+
+endif()
+
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
-	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -diag-disable 8291")
-	set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -traceback")
+    
+    set(CMAKE_Fortran_FLAGS_DEBUG "-g -debug all -traceback")
+    set(CMAKE_Fortran_FLAGS "-cpp -diag-disable 8291")
+	
+    set(OPT_FFLAGS -ip -O2 -xHost)
+
+    if(WARNINGS)
+	add_flags(Fortran "-warn all" "-warn nounused")
+	    
+	option(IFORT_CHECK_INTERFACES "If enabled and Intel Fortran is in use, then ifort will check that types passed to functions are the correct ones, and produce warnings or errors for mismatches." FALSE)
+		
+	if(NOT IFORT_CHECK_INTERFACES)
+			
+	    # disable errors from type mismatches
+	    add_flags(Fortran -warn nointerfaces)
+	endif()
+    endif()		
+		
 endif()
+
+
+# PGI, CRAY, CLANG: NOT SUPPORTED
+# --------------------------------------------------------------------
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI")
-	set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp") # force use of preprocessor for Fortran files with the "wrong" file extension
+    message(FATAL_ERROR "PGI compiler not supported by QUICK.")
+elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "CRAY")
+    message(FATAL_ERROR "CRAY compiler not supported by QUICK.")
+elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "CLANG")
+    message(FATAL_ERROR "CLANG compiler not supported by QUICK.")
 endif()
+
+
+# disable optimization flags if optimization is disabled
+if(NOT OPTIMIZE)
+	set(OPT_FFLAGS ${NO_OPT_FFLAGS})
+	set(OPT_CFLAGS ${NO_OPT_CFLAGS})
+	set(OPT_CXXFLAGS ${NO_OPT_CXXFLAGS})
+endif()
+
+#create space-separated versions of each flag set for use in PROPERTY COMPILE_FLAGS
+list_to_space_separated(OPT_FFLAGS_SPC ${OPT_FFLAGS})
+list_to_space_separated(OPT_CFLAGS_SPC ${OPT_CFLAGS})
+list_to_space_separated(OPT_CXXFLAGS_SPC ${OPT_CXXFLAGS})
+
+list_to_space_separated(NO_OPT_FFLAGS_SPC ${NO_OPT_FFLAGS})
+list_to_space_separated(NO_OPT_CFLAGS_SPC ${NO_OPT_CFLAGS})
+list_to_space_separated(NO_OPT_CXXFLAGS_SPC ${NO_OPT_CXXFLAGS})
+
 
 # blas vs lapack vs MKL selection
 if(lapack_ENABLED)

--- a/cmake/AmberCompilerConfig.cmake
+++ b/cmake/AmberCompilerConfig.cmake
@@ -10,11 +10,11 @@ set(COMPILER_HELP "
                  -----------------------------------------------------------------------
   COMPILER value | C executable | C++ executable | Fortran executable | tested versions
   --------------------------------------------------------------------------------------
-      GNU        |     gcc      |      g++       |     gfortran       | 4.4.7, 4.8.4 +
-      INTEL      |     icc      |      icpc      |     ifort          | 12 - 17
-      PGI        |     pgcc     |      pgc++     |     pgf90          | 14.9, 15.4, 16.5
+      GNU        |     gcc      |      g++       |     gfortran       | 4.8.5+
+      INTEL      |     icc      |      icpc      |     ifort          | 19
+      PGI        |     pgcc     |      pgc++     |     pgf90          | 
       CLANG      |     clang    |      clang++   |     gfortran       | 
-      CRAY       |     cc       |      CC        |     ftn            | 8.4.6*
+      CRAY       |     cc       |      CC        |     ftn            | 
   --------------------------------------------------------------------------------------
       AUTO       |   <uses the default CMake-chosen compilers>
       MANUAL     |   <uses the CC, CXX, and FC environment variables, or the 


### PR DESCRIPTION
Update defaults to match the configure based build system. Implemented in root CMakeLists.txt to prevent that compiler options will be overwritten by Amber build system when building inside of Amber. This will have to be changed in the future to make Quick independent of any Amber compiler settings.
- disable warnings so users don't get shocked
- warnings can be enabled with -DWARNINGS=TRUE
- downgrade frome -O3 to -O2 so we won't have nasty surprises with the release on untested platforms
- remove duplicate -O2 flag
- update version number to 21.03
- disable PGI, CRAY, CLANG as these have not been tested or are not working
This supersedes PR #149 which will be closed.