### PR TITLE
Fix for issue #172

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -73,7 +73,7 @@
       call print_quick_io_file(iOutFile,ierr) ! from quick_file_module
 
       ! check MPI setup and output info
-      call check_quick_mpi(iOutFile,ierr)   ! from quick_mpi_module
+      !call check_quick_mpi(iOutFile,ierr)   ! from quick_mpi_module
 
 #ifdef MPIV
       if (bMPI) call print_quick_mpi(iOutFile,ierr)   ! from quick_mpi_module

--- a/src/modules/quick_api_module.f90
+++ b/src/modules/quick_api_module.f90
@@ -250,7 +250,7 @@ subroutine set_quick_job(fqin, keywd, natoms, atomic_numbers, nxt_ptchg, ierr)
 
 #ifdef MPIV
     ! check the mpisize and turn on mpi mode
-    call check_quick_mpi(iOutFile,ierr)
+    !call check_quick_mpi(iOutFile,ierr)
 
     ! print mpi info into output
     if(bMPI) call print_quick_mpi(iOutFile,ierr)


### PR DESCRIPTION
This PR contains a fix for issue #172. MPI will be always on if the code is compiled with MPIV preprocessor flag. Note that this is a naive solution to prevent mpi hang ups when executing `quick.MPI/quick.cuda.MPI` with `mpirun -np 1`. In future, we should either remove all `bMPI` conditions from the code or put it in all mpi code paths.