### PR TITLE
Fix for issue 184

### DIFF
--- a/quick-cmake/QUICKCudaConfig.cmake
+++ b/quick-cmake/QUICKCudaConfig.cmake
@@ -139,7 +139,7 @@ if(CUDA)
 
     # optimization level
     if(OPTIMIZE)
-        list(APPEND CUDA_NVCC_FLAGS -O3)
+        list(APPEND CUDA_NVCC_FLAGS -O2)
     else()
         list(APPEND CUDA_NVCC_FLAGS -O0)
     endif()


### PR DESCRIPTION
In this PR, I have changed the nvcc optimization level in CMake build system to -O2. CUDA and CUDAMPI tests run fine as expected. Please check and merge.  