### PR TITLE
Env variable for ASE interface

### DIFF
--- a/configure
+++ b/configure
@@ -1324,7 +1324,6 @@ modfolder=$QUICK_HOME/src/modules
 
 EOF
 
-# modified 2021-09-07 by Kiyoto Aramis Tanemura. Introduce environmental variable for QUICK/ASE interface
 #  !---------------------------------------------------------------------!
 #  ! Generate quick.rc in install directory                              !
 #  !---------------------------------------------------------------------!
@@ -1334,7 +1333,6 @@ export QUICK_BASIS=\$QUICK_INSTALL/basis
 export PATH=\$QUICK_INSTALL/bin:\$PATH
 export ASE_QUICK_COMMAND=$installer
 EOF
-# end modifications by Kiyoto Aramis Tanemura on 2021-09-07
 
 if [ "$shared" = 'yes' ]; then
 libpaths=''

--- a/configure
+++ b/configure
@@ -1324,6 +1324,7 @@ modfolder=$QUICK_HOME/src/modules
 
 EOF
 
+# modified 2021-09-07 by Kiyoto Aramis Tanemura. Introduce environmental variable for QUICK/ASE interface
 #  !---------------------------------------------------------------------!
 #  ! Generate quick.rc in install directory                              !
 #  !---------------------------------------------------------------------!
@@ -1331,7 +1332,9 @@ cat > "$quick_prefix/quick.rc" << EOF
 export QUICK_INSTALL=$quick_prefix
 export QUICK_BASIS=\$QUICK_INSTALL/basis
 export PATH=\$QUICK_INSTALL/bin:\$PATH
+export ASE_QUICK_COMMAND=$installer
 EOF
+# end modifications by Kiyoto Aramis Tanemura on 2021-09-07
 
 if [ "$shared" = 'yes' ]; then
 libpaths=''


### PR DESCRIPTION
I added a line to the configure file.
The quick.rc will have an ASE_QUIC_COMMAND environmental variable so that the ASE interface will automatically use the binary specified in the sourced quick.rc