### PR TITLE
AWG - fix changes introduced in commit 22349aa14

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 * Gradient and geometry optimization calculations 
 * Mulliken charge analysis
 * Supports QM/MM calculations with Amber21
+* Fortran API to use QUICK as QM energy and force engine
 * MPI parallelization for CPU platforms
 * Massively parallel GPU implementation via CUDA for Nvidia GPUs
 * Multi-GPU support via MPI + CUDA, also across multiple compute nodes
@@ -25,8 +26,9 @@ Features
 Limitations
 -----------
 * Supports only closed shell systems
-* Supports energy/gradient calculations with basis functions up to d  
-* Supports only cartesian basis functions (no spherical harmonics)
+* Supports energy/gradient calculations with basis functions up to d
+* Supports only Cartesian basis functions (no spherical harmonics)
+* Effective core potentials (ECPs) are not supported
 * DFT calculations are performed exclusively using SG1 grid system 
 
 Installation

--- a/configure
+++ b/configure
@@ -932,7 +932,7 @@ if [ "$cuda" = 'yes' ] || [ "$cudampi" = 'yes' ]; then
 
     cudaversion=`$nvcc --version | grep 'release' | cut -d' ' -f5 | cut -d',' -f1`
 
-    if [ "$cudaversion" = "11.0" -o "$cudaversion" = "11.1" -o "$cudaversion" = "11.2" ]; then
+    if [ "$cudaversion" = "11.0" -o "$cudaversion" = "11.1" -o "$cudaversion" = "11.2" -o "$cudaversion" = "11.3" ]; then
 
       echo "CUDA Version $cudaversion detected"
 

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -100,7 +100,7 @@ module quick_method_module
         double precision :: gradCutoff     = 1.0d-7   ! gradient cutoff
         double precision :: DMCutoff       = 1.0d-10  ! density matrix cutoff
         !tol
-        double precision :: pmaxrms        = 1.0d-4   ! density matrix convergence criteria
+        double precision :: pmaxrms        = 1.0d-6   ! density matrix convergence criteria
         double precision :: aCutoff        = 1.0d-7   ! 2e cutoff
         double precision :: basisCufoff    = 1.0d-10  ! basis set cutoff
         !signif
@@ -742,7 +742,7 @@ endif
             self%gradCutoff     = 1.0d-7   ! gradient cutoff
             self%DMCutoff       = 1.0d-10  ! density matrix cutoff
 
-            self%pmaxrms        = 1.0d-4   ! density matrix convergence criteria
+            self%pmaxrms        = 1.0d-6   ! density matrix convergence criteria
             self%aCutoff        = 1.0d-7   ! 2e cutoff
             self%basisCufoff    = 1.0d-10  ! basis set cutoff
 


### PR DESCRIPTION
Commit 22349aa14
- changed default SCF convergence to 1e-4
- comments in README.md
- configure support for CUDA 11.3

These changes were mistakes. Undo here.