### PR TITLE
Fix for issue 212

### DIFF
--- a/src/cuda/gpu.cu
+++ b/src/cuda/gpu.cu
@@ -246,11 +246,22 @@ extern "C" void gpu_allocate_scratch_(){
     unsigned int store_size = gpu->blocks * gpu -> twoEThreadsPerBlock * STOREDIM_L * STOREDIM_L;
 
     gpu -> scratch -> store         = new cuda_buffer_type<QUICKDouble>(store_size);
+    gpu -> scratch -> store -> DeleteCPU();
+
     gpu -> scratch -> store2        = new cuda_buffer_type<QUICKDouble>(store_size);
+    gpu -> scratch -> store2 -> DeleteCPU();
+
     gpu -> scratch -> storeAA       = new cuda_buffer_type<QUICKDouble>(store_size);
+    gpu -> scratch -> storeAA -> DeleteCPU();
+
     gpu -> scratch -> storeBB       = new cuda_buffer_type<QUICKDouble>(store_size);
+    gpu -> scratch -> storeBB -> DeleteCPU();
+
     gpu -> scratch -> storeCC       = new cuda_buffer_type<QUICKDouble>(store_size);
+    gpu -> scratch -> storeCC -> DeleteCPU();
+
     gpu -> scratch -> YVerticalTemp = new cuda_buffer_type<QUICKDouble>(gpu->blocks * gpu -> twoEThreadsPerBlock * VDIM1 * VDIM2 * VDIM3);
+    gpu -> scratch -> YVerticalTemp -> DeleteCPU();
 
     gpu -> gpu_sim.store         = gpu -> scratch -> store -> _devData;
     gpu -> gpu_sim.store2        = gpu -> scratch -> store2 -> _devData;
@@ -258,13 +269,6 @@ extern "C" void gpu_allocate_scratch_(){
     gpu -> gpu_sim.storeBB       = gpu -> scratch -> storeBB -> _devData;
     gpu -> gpu_sim.storeCC       = gpu -> scratch -> storeCC -> _devData;
     gpu -> gpu_sim.YVerticalTemp = gpu -> scratch -> YVerticalTemp -> _devData;
-
-    gpu -> scratch -> store -> DeleteCPU();
-    gpu -> scratch -> store2 -> DeleteCPU();
-    gpu -> scratch -> storeAA -> DeleteCPU();
-    gpu -> scratch -> storeBB -> DeleteCPU();
-    gpu -> scratch -> storeCC -> DeleteCPU();
-    gpu -> scratch -> YVerticalTemp -> DeleteCPU();
 
 }
 


### PR DESCRIPTION
It turned out that temporary arrays used for ERI code dont have enough host memory when they are allocated. I was using 4GB per core; but 2 processes would require ~10 GB. Ive reorganized the code to delete host arrays as soon as they are allocated but this is pretty stupid. We should update templates to make dev only allocations in future. Will do that in a separate PR. 