### PR TITLE
Disable CUDA f functions in CMake by default

### DIFF
--- a/CMake-Options.md
+++ b/CMake-Options.md
@@ -6,7 +6,7 @@ Note that like all CMake options, these options are sticky.  Once passed to CMak
 
 #### General options
 - `-DCOMPILER`: Allows selection of the toolchain to use.  `-DCOMPILER=AUTO` to use CMake default behavior.  Run CMake with no arguments to see the list of options.
-- `-DNOF=TRUE`: Disables the compilation of time consuming f functions in the ERI code of cuda version. Not recommended for production.
+- `-DNOF=<TRUE|FALSE>`: Disables the compilation of time consuming f functions in the ERI code of cuda version.  True by default (f-functions not yet supported)
 - `-DCMAKE_BUILD_TYPE=<Debug|Release>`: Controls whether to build with debugging symbols (`Debug`) or not (`Release`).
 - `-DOPTIMIZE=<TRUE|FALSE>`: Controls whether to enable compiler optimizations.  On by default.
 - `-DCMAKE_INSTALL_PREFIX=...`: Controls where QUICK will be installed when you run `make install`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT INSIDE_AMBER)
 
 endif()
 
-option(NOF "Disables the compilation of QUICK's time consuming f functions in the ERI code of cuda version. Not recommended for production." FALSE)
+option(NOF "Disables the compilation of QUICK's time consuming f functions in the ERI code of cuda version. Not recommended for production." TRUE)
 
 # Compiler flags
 # These should really go into cmake/CompilerFlags.cmake but with the


### PR DESCRIPTION
The f function code produces wrong numbers. Disable it by default.