### PR TITLE
Rolling back to old anlytical sswder code

### DIFF
--- a/src/cuda/gpu_getxc.cu
+++ b/src/cuda/gpu_getxc.cu
@@ -164,9 +164,9 @@ void getxc_grad(_gpu_type gpu){
 
     prune_grid_sswgrad();
 
-    //QUICK_SAFE_CALL((get_sswgrad_kernel<<<gpu->blocks, gpu->xc_threadsPerBlock, gpu -> gpu_xcq -> smem_size>>>()));
+    QUICK_SAFE_CALL((get_sswgrad_kernel<<<gpu->blocks, gpu->xc_threadsPerBlock, gpu -> gpu_xcq -> smem_size>>>()));
 
-    QUICK_SAFE_CALL((get_sswnumgrad_kernel<<< gpu->blocks, gpu->sswGradThreadsPerBlock, gpu -> gpu_xcq -> smem_size>>>()));
+    //QUICK_SAFE_CALL((get_sswnumgrad_kernel<<< gpu->blocks, gpu->sswGradThreadsPerBlock, gpu -> gpu_xcq -> smem_size>>>()));
 
     cudaDeviceSynchronize();
 

--- a/src/cuda/gpu_getxc.h
+++ b/src/cuda/gpu_getxc.h
@@ -521,7 +521,7 @@ __global__ void cshell_getxcgrad_kernel()
       devSim_dft.exc[gid] = _tmp;
 #endif
 
-      QUICKDouble sumGradx=0.0, sumGrady=0.0, sumGradz=0.0;
+      //QUICKDouble sumGradx=0.0, sumGrady=0.0, sumGradz=0.0;
 
       for (int i = bfloc_st; i< bfloc_end; i++) {
         int ibas = devSim_dft.basf[i];
@@ -578,6 +578,7 @@ __global__ void cshell_getxcgrad_kernel()
                     + zdotb * (dzdz * phi2 + dphidz * dphidz2));
 #endif
 
+/*
 #ifdef CEW
 
             if(devSim_dft.use_cew){
@@ -591,24 +592,24 @@ __global__ void cshell_getxcgrad_kernel()
 
             }
 #endif
-
+*/
             GRADADD(smemGrad[Istart], Gradx);
             GRADADD(smemGrad[Istart+1], Grady);
             GRADADD(smemGrad[Istart+2], Gradz);
 
-            sumGradx += Gradx;
+/*            sumGradx += Gradx;
             sumGrady += Grady;
             sumGradz += Gradz;
-
+*/
           }
         }
       }
 
-      int Istart = (devSim_dft.gatm[gid]-1) * 3;
+/*      int Istart = (devSim_dft.gatm[gid]-1) * 3;
       GRADADD(smemGrad[Istart], -sumGradx);
       GRADADD(smemGrad[Istart+1], -sumGrady);
       GRADADD(smemGrad[Istart+2], -sumGradz);
-
+*/
     }
     //Set weights for sswder calculation
     if(density < devSim_dft.DMCutoff){


### PR DESCRIPTION
In this PR, I have made necessary change to disable numerical grid weight derivatives and enable old analytical implementation. 