### PR TITLE
Rolling back to old analytical sswder implementation in host code

### DIFF
--- a/src/modules/include/gradient.fh
+++ b/src/modules/include/gradient.fh
@@ -1287,7 +1287,7 @@ contains
                     icount=icount+1
                     enddo
 
-#define TOTALDERIV
+!#define TOTALDERIV
 
 #ifdef TOTALDERIV
                     ! new


### PR DESCRIPTION
In a previous PR I disabled numerical sswder in device code; but I forgot to do the same in host code. In this PR, I have done this. 