### PR TITLE
ERI grad cutoff fix

### DIFF
--- a/src/cuda/gpu_get2e_subs_grad.h
+++ b/src/cuda/gpu_get2e_subs_grad.h
@@ -142,8 +142,8 @@ __launch_bounds__(SM_2X_GRAD_THREADS_PER_BLOCK, 1) getGrad_kernel_spdf8()
                                             MAX(LOC2(devSim.cutMatrix, jj, kk, nshell, nshell),     LOC2(devSim.cutMatrix, jj, ll, nshell, nshell))));
                 
                 
-                if ((LOC2(devSim.YCutoff, kk, ll, nshell, nshell) * LOC2(devSim.YCutoff, ii, jj, nshell, nshell))> devSim.integralCutoff && \
-                    (LOC2(devSim.YCutoff, kk, ll, nshell, nshell) * LOC2(devSim.YCutoff, ii, jj, nshell, nshell) * DNMax) > devSim.integralCutoff) {
+                if ((LOC2(devSim.YCutoff, kk, ll, nshell, nshell) * LOC2(devSim.YCutoff, ii, jj, nshell, nshell))> devSim.gradCutoff && \
+                    (LOC2(devSim.YCutoff, kk, ll, nshell, nshell) * LOC2(devSim.YCutoff, ii, jj, nshell, nshell) * DNMax) > devSim.gradCutoff) {
                     
                     int iii = devSim.sorted_Qnumber[II];
                     int jjj = devSim.sorted_Qnumber[JJ];
@@ -776,7 +776,7 @@ QUICKDouble* YVerticalTemp, QUICKDouble* store, QUICKDouble* store2, QUICKDouble
             int LLL = (int) j/kPrimK;
             int KKK = (int) j-kPrimK*LLL;
             
-            if (cutoffPrim * LOC2(devSim.cutPrim, kStartK+KKK, kStartL+LLL, devSim.jbasis, devSim.jbasis) > devSim.integralCutoff) {
+            if (cutoffPrim * LOC2(devSim.cutPrim, kStartK+KKK, kStartL+LLL, devSim.jbasis, devSim.jbasis) > devSim.primLimit) {
                 
                 QUICKDouble CC = LOC2(devSim.gcexpo, KKK , devSim.Ksumtype[KK] - 1, MAXPRIM, devSim.nbasis);
                 /*

--- a/src/modules/include/eri_grad.fh
+++ b/src/modules/include/eri_grad.fh
@@ -116,7 +116,7 @@ subroutine cshell_eri_grad
             do KKK=1,quick_basis%kprim(KK)
                Nprik=quick_basis%kstart(KK)+KKK-1
                cutoffprim=cutoffprim1*cutprim(Nprik,Npril)
-               if(cutoffprim.gt.quick_method%gradCutoff)then
+               if(cutoffprim.gt.quick_method%primLimit)then
                   CD=Apri(Nprik,Npril)
                   ABCD=AB+CD
                   ROU=AB*CD/ABCD
@@ -252,7 +252,7 @@ subroutine iclass_grad_cshell(I,J,K,L,NNA,NNC,NNAB,NNCD,NNABfirst,NNCDfirst)
                Nprik=quick_basis%kstart(KK)+KKK-1
                CC=quick_basis%gcexpo(KKK,quick_basis%ksumtype(KK))
                cutoffprim=cutoffprim1*cutprim(Nprik,Npril)
-               if(cutoffprim.gt.quick_method%gradCutoff)then
+               if(cutoffprim.gt.quick_method%primLimit)then
                   ITT=ITT+1
                   quick_scratch%X44(ITT)=X2*quick_basis%Xcoeff(Nprik,Npril,K,L)
                   quick_scratch%X44AA(ITT)=quick_scratch%X44(ITT)*AA*2.0d0

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -95,7 +95,7 @@ module quick_method_module
         integer :: maxdiisscf = 10
 
         ! start cycle for delta density cycle
-        integer :: ncyc =5
+        integer :: ncyc =3
 
         ! following are some cutoff criteria
         double precision :: coreIntegralCutoff = 1.0d-12 ! cutoff for 1e integral prescreening
@@ -808,7 +808,7 @@ module quick_method_module
             self%iscf = 200
             self%maxdiisscf = 10
             self%iopt = 0
-            self%ncyc = 5
+            self%ncyc = 3
 
             self%integralCutoff = 1.0d-7   ! integral cutoff
             self%leastIntegralCutoff = LEASTCUTOFF


### PR DESCRIPTION
I performed a series of HF/DEF2-SVP gradient tests after fixing the the grad cutoff (after commit #53ebb725ea816f0fdde5676ab258c43423493e5d). Everything looks good (see below).  Note that the comparison is wrt. reference data taken from software X. 

```
2-AminoadipicAcid energy = 7.09e-07, Passed; grad = 5.54e-06, Passed 

AbscisicAcid energy = 7.16e-07, Passed; grad = 5.57e-06, Passed 

Anserine energy = 1.09e-06, Passed; grad = 7.49e-06, Passed 

Asparagine energy = 7.68e-07, Passed; grad = 5.69e-06, Passed 

Carnosine energy = 1.07e-06, Passed; grad = 6.71e-06, Passed 

Citrulline energy = 8.08e-07, Passed; grad = 5.69e-06, Passed 

Glutamine energy = 8.94e-07, Passed; grad = 5.73e-06, Passed 

GuanidinoaceticAcid energy = 6.56e-07, Passed; grad = 5.34e-06, Passed 

HippuricAcid energy = 8.61e-07, Passed; grad = 5.90e-06, Passed 

KynurenicAcid energy = 6.91e-07, Passed; grad = 6.17e-06, Passed 

Mimosine energy = 1.05e-06, Passed; grad = 6.46e-06, Passed 

Naproxen energy = 6.53e-07, Passed; grad = 8.79e-06, Passed 

NicotinicAcid energy = 5.73e-07, Passed; grad = 5.79e-06, Passed 

N-Methyl-L-glutamate energy = 9.41e-07, Passed; grad = 7.31e-06, Passed 

NN-Dimethylglycine energy = 5.91e-07, Passed; grad = 6.35e-06, Passed 

Ornithine energy = 5.15e-07, Passed; grad = 5.35e-06, Passed 

O-Succinyl-L-homoserine energy = 1.13e-06, Passed; grad = 8.74e-06, Passed 

QuinolinicAcid energy = 7.32e-07, Passed; grad = 5.93e-06, Passed 

SalicylicAcid energy = 6.56e-06, Passed; grad = 2.17e-05, Passed 

Serotonin energy = 4.35e-07, Passed; grad = 6.24e-06, Passed 

Tryptophan energy = 7.08e-07, Passed; grad = 8.56e-06, Passed 

Tyrosine energy = 6.43e-07, Passed; grad = 7.80e-06, Passed 

```
