### PR TITLE
Pointer arithmetic fix in 3 center integral code

### DIFF
--- a/src/cuda/gpu_lri_subs.h
+++ b/src/cuda/gpu_lri_subs.h
@@ -191,11 +191,11 @@ __launch_bounds__(SM_2X_2E_THREADS_PER_BLOCK, 1) get_lri_kernel_spdf2()
                 // assign values to dummy variables, to be cleaned up eventually
                 //for(int iatom=0; iatom < devSim.natom+devSim.nextatom; iatom++ ){ 
 #ifdef int_spd
-                    iclass_lri(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp, devSim.store);
+                    iclass_lri(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside);
                 
 #elif defined int_spdf2
                 if ( (iii + jjj) > 4 && (iii + jjj) <= 6 ) {
-                    iclass_lri_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp, devSim.store);
+                    iclass_lri_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside);
                 }
                 
 #endif

--- a/src/cuda/gpu_lri_subs_grad.h
+++ b/src/cuda/gpu_lri_subs_grad.h
@@ -104,7 +104,7 @@ get_lri_grad_kernel_spdf2()
                     iclass_lri_grad(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside, devSim.store2+offside, devSim.storeAA+offside, devSim.storeBB+offside);
 #elif defined int_spdf2
                     if ( (iii + jjj) >= 4 ) {
-                        iclass_lri_grad_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside, devSim.store2+offside, devSim.storeAA, devSim.storeBB+offside);
+                        iclass_lri_grad_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside, devSim.store2+offside, devSim.storeAA+offside, devSim.storeBB+offside);
                     }
 #endif
                        

--- a/src/cuda/gpu_lri_subs_grad.h
+++ b/src/cuda/gpu_lri_subs_grad.h
@@ -101,10 +101,10 @@ get_lri_grad_kernel_spdf2()
                     int iii = devSim.sorted_Qnumber[II];
                     int jjj = devSim.sorted_Qnumber[JJ];
 #ifdef int_spd
-                    iclass_lri_grad(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp, devSim.store, devSim.store2, devSim.storeAA, devSim.storeBB);
+                    iclass_lri_grad(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside, devSim.store2+offside, devSim.storeAA+offside, devSim.storeBB+offside);
 #elif defined int_spdf2
                     if ( (iii + jjj) >= 4 ) {
-                        iclass_lri_grad_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp, devSim.store, devSim.store2, devSim.storeAA, devSim.storeBB);
+                        iclass_lri_grad_spdf2(iii, jjj, ii, jj, iatom, totalatom, devSim.YVerticalTemp+offside, devSim.store+offside, devSim.store2+offside, devSim.storeAA, devSim.storeBB+offside);
                     }
 #endif
                        


### PR DESCRIPTION
In this PR I have fixed some incorrect pointer arithmetic in 3 center integral code. This fixes wrong energy and gradients currently observed in CEW tests. 