### PR TITLE
Protect the loop exit condition with MAX_DII_CYCLE

### DIFF
--- a/src/modules/quick_scf_module.f90
+++ b/src/modules/quick_scf_module.f90
@@ -180,7 +180,7 @@ contains
      logical :: diisdone = .false.  ! flag to indicate if diis is done
      logical :: deltaO   = .false.  ! delta Operator
      integer :: idiis = 0           ! diis iteration
-     integer :: IDIISfinal,iidiis,current_diis
+     integer :: IDIISfinal,iidiis,current_diis, MAX_DII_CYCLE
      integer :: lsolerr = 0
      integer :: IDIIS_Error_Start, IDIIS_Error_End
      double precision :: BIJ,DENSEJI,errormax,OJK,temp
@@ -234,6 +234,8 @@ contains
      call allocate_quick_scf(ierr)
   
      if(master) then
+        ! precompute the MAX_DII_CYCLE 
+        MAX_DII_CYCLE = MAX_DII_CYCLE_TIME*quick_method%maxdiisscf
         write(ioutfile,'(40x," SCF ENERGY")')
         if (quick_method%printEnergy) then
            write(ioutfile,'("| ",120("-"))')
@@ -751,7 +753,11 @@ contains
               diisdone=.true.
               quick_method%scf_conv=.false.
            endif
-           diisdone = idiis.gt.MAX_DII_CYCLE_TIME*quick_method%maxdiisscf .or. diisdone
+
+           ! assess whether to leave the SCF convergence due to the limit on MAX_DII_CYCLE
+           if(MAX_DII_CYCLE > quick_method%iscf-1) then
+              diisdone = idiis.gt.MAX_DII_CYCLE .or. diisdone
+           endif 
   
            if((tmp .ne. quick_method%integralCutoff).and. .not.diisdone) then
               write(ioutfile, '("| -------------- 2E-INT CUTOFF CHANGE TO ", E10.4, " ------------")') quick_method%integralCutoff


### PR DESCRIPTION
With the current setup, the SCF loop is interrupted after 300 iterations even when `SCF=VALUE` key contains `VALUE` more than 300 (tried with 1000).

The 300 is the result of `MAX_DII_CYCLE_TIME*quick_method%maxdiisscf`, where `MAX_DII_CYCLE_TIME` hardcoded value is 30 and the default `maxdiisscf` value is 10.

This PR fixes this issue so that the current loop break condition is only checked when the total number of DIIS cycles (I  named it `MAX_DII_CYCLE`) is more than the max number of SCF cycles.

Alternatively, the control of the `MAX_DII_CYCLE_TIME` can be given to the user by supplying the corresponding input keyword. Let me know if this might be of interest.

**Note:** I have only patched the conventional SCF module. The same fix can be applied in `quick_uscf_module.f90` and `quick_sad_guess_module.f90` modules.