### PR TITLE
Fix for GitHub CI test failure

### DIFF
--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
-        run: sudo apt-get -y install gfortran openmpi-bin
+        run: sudo apt-get -y install gfortran openmpi-bin openmpi-common
       - name: Configure mpi
         run: ./configure --mpi --prefix $PWD/install gnu
       - name: Build mpi

--- a/.github/workflows/mpi.yml
+++ b/.github/workflows/mpi.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
-        run: sudo apt-get -y install gfortran openmpi-bin openmpi-common
+        run: sudo apt-get -y install gfortran openmpi-bin openmpi-common libopenmpi-dev
       - name: Configure mpi
         run: ./configure --mpi --prefix $PWD/install gnu
       - name: Build mpi
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install deps
-        run: sudo apt-get -y install gfortran cmake openmpi-bin
+        run: sudo apt-get -y install gfortran cmake openmpi-bin openmpi-common libopenmpi-dev
       - name: Configure MPI
         run: |
              mkdir build


### PR DESCRIPTION
The changes in this PR should fix CI test failure reported in issue #271. Please close #272 and delete [Madu86:ci-fix ](https://github.com/Madu86/QUICK/tree/ci-fix) branch after merging. 