### PR TITLE
AWG: Remove redundant hard-coded SCF DIIS exit condition

### DIFF
--- a/src/modules/quick_sad_guess_module.f90
+++ b/src/modules/quick_sad_guess_module.f90
@@ -855,7 +855,6 @@ contains
            if(verbose) write (ioutfile,'(" PERFORM FINAL NO INTERPOLATION ITERATION")')
            diisdone=.true.
         endif
-        diisdone = idiis.gt.MAX_DII_CYCLE_TIME*quick_method%maxdiisscf .or. diisdone
   
         if((tmp .ne. quick_method%integralCutoff).and. .not.diisdone) then
            if(verbose) write(ioutfile, '("| -------------- 2E-INT CUTOFF CHANGE TO ", E10.4, " ------------")') &

--- a/src/modules/quick_scf_module.f90
+++ b/src/modules/quick_scf_module.f90
@@ -337,7 +337,7 @@ contains
         else
            IDIISfinal=quick_method%maxdiisscf; iidiis=1
         endif
-        write(ioutfile,'(a,i3,3x,a,i3,3x,a,i3)') 'idiis =', idiis, 'jscf =', jscf, 'iidiis =', iidiis
+
         !-----------------------------------------------
         ! Before Delta Densitry Matrix, normal operator is implemented here
         !-----------------------------------------------
@@ -723,7 +723,6 @@ contains
 #endif
            current_diis=mod(idiis-1,quick_method%maxdiisscf)
            current_diis=current_diis+1
-           write(ioutfile,'(a,i3)') 'current_diis =', current_diis
 
            ! DELETE ME
            !write(*,'(A,3es20.10)')"SCF Iter",quick_qm_struct%Ecore,quick_qm_struct%Eel, & ! DELETE ME

--- a/src/modules/quick_scf_module.f90
+++ b/src/modules/quick_scf_module.f90
@@ -337,6 +337,7 @@ contains
         else
            IDIISfinal=quick_method%maxdiisscf; iidiis=1
         endif
+        write(ioutfile,'(a,i3,3x,a,i3,3x,a,i3)') 'idiis =', idiis, 'jscf =', jscf, 'iidiis =', iidiis
         !-----------------------------------------------
         ! Before Delta Densitry Matrix, normal operator is implemented here
         !-----------------------------------------------
@@ -722,6 +723,7 @@ contains
 #endif
            current_diis=mod(idiis-1,quick_method%maxdiisscf)
            current_diis=current_diis+1
+           write(ioutfile,'(a,i3)') 'current_diis =', current_diis
 
            ! DELETE ME
            !write(*,'(A,3es20.10)')"SCF Iter",quick_qm_struct%Ecore,quick_qm_struct%Eel, & ! DELETE ME
@@ -779,7 +781,6 @@ contains
               diisdone=.true.
               quick_method%scf_conv=.false.
            endif
-           diisdone = idiis.gt.MAX_DII_CYCLE_TIME*quick_method%maxdiisscf .or. diisdone
   
            if((tmp .ne. quick_method%integralCutoff).and. .not.diisdone) then
               write(ioutfile, '("| -------------- 2E-INT CUTOFF CHANGE TO ", E10.4, " ------------")') quick_method%integralCutoff

--- a/src/modules/quick_size_module.f90
+++ b/src/modules/quick_size_module.f90
@@ -32,9 +32,5 @@ module quick_size_module
     ! Minimal iteration for SCF
     integer, parameter :: MIN_SCF = 3
     
-    ! MAX DIIS CYCLE= MAX_DII_CYCLE_TIME* MAXDIICYC
-    ! notice the difference between this and ISCF
-    integer,parameter :: MAX_DII_CYCLE_TIME = 30
-
     integer,parameter :: MAXPRIM = 10
 end module quick_size_module

--- a/src/modules/quick_uscf_module.f90
+++ b/src/modules/quick_uscf_module.f90
@@ -878,7 +878,6 @@ contains
               diisdone=.true.
               quick_method%uscf_conv=.false.
            endif
-           diisdone = idiis.gt.MAX_DII_CYCLE_TIME*quick_method%maxdiisscf .or. diisdone
   
            if((tmp .ne. quick_method%integralCutoff).and. .not.diisdone) then
               write(ioutfile, '("| -------------- 2E-INT CUTOFF CHANGE TO ", E10.4, " ------------")') quick_method%integralCutoff


### PR DESCRIPTION
The exit condition `idiis.gt.MAX_DII_CYCLE_TIME*quick_method%maxdiisscf` is 1) redundant in the current implementation and 2) leads to a hard-coded maximum number of SCF iterations (DIIS subspace size times hardcoded number of maximum DIIS iterations). This is dumb, also because `idiis` is always equal `jscf`, hence it is sufficient to check for `jscf` as exit condition to limit the number of SCF iterations.

Here we remove the redundant condition and get rid of unnecessary `MAX_DII_CYCLE_TIME`. The user can choose the number of SCF iterations and size of DIIS subspace. There is no need to limit the number of DIIS cycles.