### PR TITLE
Increase keywd length

### DIFF
--- a/src/modules/quick_api_module.f90
+++ b/src/modules/quick_api_module.f90
@@ -62,8 +62,8 @@ module quick_api_module
     double precision, allocatable, dimension(:,:) :: ptchg_crd
 
     ! job card for quick job, essentially the first line of regular quick input file
-    ! default length is 200 characters
-    character(len=200) :: keywd
+    ! default length is 256 characters
+    character(len=256) :: keywd
 
     ! Is the job card provided by passing a string? default is false
     logical :: hasKeywd = .false.
@@ -164,10 +164,10 @@ subroutine check_fqin(fqin, keywd, ierr)
   implicit none
 
   character(len=80), intent(in)  :: fqin
-  character(len=200), intent(in) :: keywd
+  character(len=256), intent(in) :: keywd
   integer, intent(inout) :: ierr
 
-  call upcase(keywd, 200)
+  call upcase(keywd, 256)
 
   if ((index(keywd, 'HF') .ne. 0) .or. (index(keywd, 'DFT') .ne. 0) .and. (index(keywd, 'BASIS=') .ne. 0 )) then
     quick_api%hasKeywd = .true.
@@ -194,7 +194,7 @@ subroutine set_quick_job(fqin, keywd, natoms, atomic_numbers, reusedmx, ierr)
   implicit none
 
   character(len=80), intent(in)  :: fqin
-  character(len=200), intent(in) :: keywd
+  character(len=256), intent(in) :: keywd
   integer, intent(in) :: natoms
   integer, intent(in) :: atomic_numbers(natoms)
   logical, intent(in) :: reusedmx

--- a/src/quick_api_test.f90
+++ b/src/quick_api_test.f90
@@ -47,7 +47,7 @@
     character(len=80) :: fname
 
     ! job card
-    character(len=200) :: keywd
+    character(len=256) :: keywd
 
     ! total qm energy, mulliken charges, gradients and point charge gradients
     double precision :: totEne


### PR DESCRIPTION
Match API keyword string length to Amber.
Increase from 200 to 256.
Longer is better to prevent truncation e.g. with long libxc functional names etc.