### PR TITLE
CUDA build updates

### DIFF
--- a/configure
+++ b/configure
@@ -48,8 +48,9 @@ echo  "
       --debug        Compiles debug version                                 
       --debug-time   Compiles a debug version that reports more information
                      on timing
+      --profile      Compiles profiling version                                 
       --shared       Build shared object libraries                          
-      --arch <kepler|maxwell|pascal|volta|turing|ampere|hopper>                                           
+      --arch <kepler|maxwell|pascal|volta|turing|ampere|adalovelace|hopper>                                           
                      Specify gpu architecture. Applicable for cuda and      
                      cudampi versions only. If unspecified, QUICK will be   
                      compiled for several architectures based on the CUDA   
@@ -561,6 +562,7 @@ hip='no'
 hipmpi='no'
 debug='no'
 debugtime='no'
+profile='no'
 buildtypes=''
 installers=''
 
@@ -633,6 +635,12 @@ cc_debug_flags=''
 cxx_debug_flags=''
 cuda_debug_flags=''
 
+# profile flags
+fort_profile_flags=''
+cc_profile_flags=''
+cxx_profile_flags=''
+cuda_profile_flags=''
+
 # compiler version specific flags
 fort_vspec_flags=''
 
@@ -693,6 +701,7 @@ while [ $# -gt 0 ]; do
     --hipmpi)      hipmpi='yes'; buildtypes="$buildtypes hipmpi"; cleantypes="$cleantypes hipmpiclean"; installers="$installers quick.hip.MPI";;
     --debug-time)  debugtime='yes';;
     --debug)       debug='yes';;
+    --profile)     profile='yes';;
     --verbose)     verbose='';;
     --mirp)        mirp='yes';;
     --shared)      shared='yes';;
@@ -945,8 +954,8 @@ set_uspec_arch(){
   for carch in $cuda_arch; do
     case "$carch" in
       kepler)
-	echo "Configuring for SM3.0"
-	cuda_arch_flags="$cuda_arch_flags $sm30flags -DUSE_LEGACY_ATOMICS"
+	echo "Configuring for SM3.5"
+	cuda_arch_flags="$cuda_arch_flags $sm35flags -DUSE_LEGACY_ATOMICS"
 	cuda_dc_flags='-Xptxas --disable-optimizer-constants';;
       maxwell)
         echo "Configuring for SM5.0"
@@ -969,6 +978,9 @@ set_uspec_arch(){
       ampere)
         echo "Configuring for SM8.0"
         cuda_arch_flags="$cuda_arch_flags $sm80flags";;
+      adalovelace)
+        echo "Configuring for SM8.9"
+        cuda_arch_flags="$cuda_arch_flags $sm89flags";;
       hopper)
         echo "Configuring for SM9.0"
         cuda_arch_flags="$cuda_arch_flags $sm90flags";;
@@ -989,24 +1001,32 @@ if [ "$cuda" = 'yes' ] || [ "$cudampi" = 'yes' ]; then
   fi
 
   if [ -z "$NVCC" ]; then nvcc="$CUDA_HOME/bin/nvcc"; else nvcc="$NVCC"; fi
-    #SM9.0 = H100
+  #SM9.0 = H100, GH200 (Hopper)
     sm90flags='-gencode arch=compute_90,code=sm_90'
-    #SM8.0 = A100
+    #SM8.9 = L4, L400 (Ada Lovelace)
+    sm89flags='-gencode arch=compute_89,code=sm_89'
+    #SM8.6 = A2, A10, A16, A40 (Ampere)
+    sm86flags='-gencode arch=compute_86,code=sm_86'
+    #SM8.0 = A30, A100 (Ampere)
     sm80flags='-gencode arch=compute_80,code=sm_80'
-    #SM7.5 = RTX20xx, Tesla T4, Quadro RTX, RTX Titan
+    #SM7.5 = RTX20xx, Tesla T4, Quadro RTX, RTX Titan (Turing)
     sm75flags='-gencode arch=compute_75,code=sm_75'
-    #SM7.0 = V100, Titan V
+    #SM7.0 = V100, Titan V (Volta)
     sm70flags='-gencode arch=compute_70,code=sm_70'
-    #SM6.0 = GP100 / P100 = DGX-1
+    #SM6.0 = GP100 / P100 = DGX-1 (Pascal)
     sm60flags='-gencode arch=compute_60,code=sm_60'
-    #SM5.0 = M40
+    #SM5.0 = M40 (Maxwell)
     sm50flags='-gencode arch=compute_50,code=sm_50'
-    #SM3.0 = K80, K40, K20
+    #SM3.7 = GK210 = K80 -- not currently used, since SM3.0 may be better (Kepler)
+    sm37flags='-gencode arch=compute_37,code=sm_37'
+    #SM3.5 = GK110 + 110B = K20, K20X, K40, GTX780, GTX-Titan, GTX-Titan-Black, GTX-Titan-Z (Kepler)
+    sm35flags='-gencode arch=compute_35,code=sm_35'
+    #SM3.0 = GK104 = K10, GTX680, 690 etc. (Kepler)
     sm30flags='-gencode arch=compute_30,code=sm_30'
 
     cudaversion=`$nvcc --version | grep 'release' | cut -d' ' -f5 | cut -d',' -f1`
 
-    if [ "$cudaversion" = "11.0" -o "$cudaversion" = "11.1" -o "$cudaversion" = "11.2" -o "$cudaversion" = "11.3" -o "$cudaversion" = "11.4" -o "$cudaversion" = "11.5" -o "$cudaversion" = "11.6" -o "$cudaversion" = "11.7" -o "$cudaversion" = "11.8" -o "$cudaversion" = "12.0" ]; then
+    if [ "$cudaversion" = "12.0" -o "$cudaversion" = "12.1" -o "$cudaversion" = "12.2" -o "$cudaversion" = "12.3" ]; then
 
       echo "CUDA Version $cudaversion detected"
 
@@ -1014,8 +1034,44 @@ if [ "$cuda" = 'yes' ] || [ "$cudampi" = 'yes' ]; then
         set_uspec_arch
       else
 
-        echo "Configuring for SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM9.0"
-        cuda_arch_flags="$sm50flags $sm60flags $sm70flags $sm75flags $sm80flags $sm90flags -DUSE_LEGACY_ATOMICS"
+        echo "Configuring for SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6, SM8.9, SM9.0"
+        cuda_arch_flags="$sm50flags $sm60flags $sm70flags $sm75flags $sm80flags $sm86flags $sm89flags $sm90flags -DUSE_LEGACY_ATOMICS"
+        cuda_dc_flags='-Xptxas --disable-optimizer-constants'
+      fi
+    elif [ "$cudaversion" = "11.8" ]; then
+
+      echo "CUDA Version $cudaversion detected"
+
+      if [ "$uspec_arch" = 'true' ]; then
+        set_uspec_arch
+      else
+
+        echo "Configuring for SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6, SM8.9, SM9.0"
+        cuda_arch_flags="$sm35flags $sm37flags $sm50flags $sm60flags $sm70flags $sm75flags $sm80flags $sm86flags $sm89flags $sm90flags -DUSE_LEGACY_ATOMICS"
+        cuda_dc_flags='-Xptxas --disable-optimizer-constants'
+      fi
+    elif [ "$cudaversion" = "11.1" -o "$cudaversion" = "11.2" -o "$cudaversion" = "11.3" -o "$cudaversion" = "11.4" -o "$cudaversion" = "11.5" -o "$cudaversion" = "11.6" -o "$cudaversion" = "11.7" ]; then
+
+      echo "CUDA Version $cudaversion detected"
+
+      if [ "$uspec_arch" = 'true' ]; then
+        set_uspec_arch
+      else
+
+        echo "Configuring for SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6"
+        cuda_arch_flags="$sm35flags $sm37flags $sm50flags $sm60flags $sm70flags $sm75flags $sm80flags $sm86flags -DUSE_LEGACY_ATOMICS"
+        cuda_dc_flags='-Xptxas --disable-optimizer-constants'
+      fi
+    elif [ "$cudaversion" = "11.0" ]; then
+
+      echo "CUDA Version $cudaversion detected"
+
+      if [ "$uspec_arch" = 'true' ]; then
+        set_uspec_arch
+      else
+
+        echo "Configuring for SM3.0, SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0"
+        cuda_arch_flags="$sm30flags $sm35flags $sm37flags $sm50flags $sm60flags $sm70flags $sm75flags $sm80flags -DUSE_LEGACY_ATOMICS"
         cuda_dc_flags='-Xptxas --disable-optimizer-constants'
       fi
     elif [ "$cudaversion" = "10.0" -o "$cudaversion" = "10.1" -o "$cudaversion" = "10.2" ]; then
@@ -1050,7 +1106,7 @@ if [ "$cuda" = 'yes' ] || [ "$cudampi" = 'yes' ]; then
       fi
     else
       echo  "Error: Unsupported CUDA version $cudaversion detected. "
-      echo  "       QUICK requires at least CUDA version 8.0 "
+      echo  "       QUICK requires CUDA version >= 8.0 and <= 12.3.  Please upgrade your CUDA installation or disable building with CUDA. "
       exit 1
     fi
 
@@ -1157,6 +1213,13 @@ elif [ "$debugtime" = 'yes' ]; then
   fi
 fi
 
+# set profile flags
+if [ "$profile" = 'yes' ]; then
+  if [ "$cuda" = 'yes' -o "$cudampi" = 'yes' ]; then
+    cuda_profile_flags='--generate-line-info'
+  fi
+fi
+
 # set library flags if so library is requested
 if [ "$shared" = 'yes' ]; then
   lib_flags='-fPIC'
@@ -1221,7 +1284,7 @@ for buildtype in $buildtypes; do
 
     cpp_flags="$opt_flags -I$CUDA_HOME/include $lib_flags -DCUBLAS_USE_THUNKING"
 
-    cuda_flags="$opt_flags $cuda_debug_flags $cuda_ext_flags $cuda_arch_flags $cuda_lib_flags -Wno-deprecated-gpu-targets"
+    cuda_flags="$opt_flags $cuda_debug_flags $cuda_profile_flags $cuda_ext_flags $cuda_arch_flags $cuda_lib_flags -Wno-deprecated-gpu-targets"
 
     cuda_incl_flags="-L$CUDA_HOME/lib64 -I$CUDA_HOME/include"
 

--- a/quick-cmake/QUICKCudaConfig.cmake
+++ b/quick-cmake/QUICKCudaConfig.cmake
@@ -17,33 +17,33 @@ if(CUDA)
     set(CUDA_NVCC_FLAGS "")
 
     set(CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
-    #SM9.0 = H100
+    #SM9.0 = H100, GH200 (Hopper)
     set(SM90FLAGS -gencode arch=compute_90,code=sm_90)
-    #SM8.6 -- not currently used, but should be tested on Cuda 11.1
+    #SM8.9 = L4, L40 (Ada Lovelace)
+    set(SM89FLAGS -gencode arch=compute_89,code=sm_89)
+    #SM8.6 = A2, A10, A16, A40 (Ampere)
     set(SM86FLAGS -gencode arch=compute_86,code=sm_86)
-    #SM8.0 = A100
+    #SM8.0 = A30, A100 (Ampere)
     set(SM80FLAGS -gencode arch=compute_80,code=sm_80)
-    #SM7.5 = RTX20xx, RTX Titan, T4 and Quadro RTX
+    #SM7.5 = RTX20xx, RTX Titan, T4 and Quadro RTX (Turing)
     set(SM75FLAGS -gencode arch=compute_75,code=sm_75)        
-    #SM7.0 = V100 and Volta Geforce / GTX Ampere?
+    #SM7.0 = V100 and Volta Geforce / GTX Ampere? (Volta)
     set(SM70FLAGS -gencode arch=compute_70,code=sm_70)
-    #SM6.2 = ??? 
-    set(SM62FLAGS -gencode arch=compute_62,code=sm_62)
-    #SM6.1 = GP106 = GTX-1070, GP104 = GTX-1080, GP102 = Titan-X[P]
+    #SM6.1 = GP106 = GTX-1070, GP104 = GTX-1080, GP102 = Titan-X[P] (Pascal)
     set(SM61FLAGS -gencode arch=compute_61,code=sm_61)
-    #SM6.0 = GP100 / P100 = DGX-1
+    #SM6.0 = GP100 / P100 = DGX-1 (Pascal)
     set(SM60FLAGS -gencode arch=compute_60,code=sm_60)
-    #SM5.3 = GM200 [Grid] = M60, M40?
+    #SM5.3 = GM200 [Grid] = M60, M40 (Maxwell)
     set(SM53FLAGS -gencode arch=compute_53,code=sm_53)
-    #SM5.2 = GM200 = GTX-Titan-X, M6000 etc.
+    #SM5.2 = GM200 = GTX-Titan-X, M6000 etc (Maxwell)
     set(SM52FLAGS -gencode arch=compute_52,code=sm_52)
-    #SM5.0 = GM204 = GTX980, 970 etc
+    #SM5.0 = GM204 = GTX980, 970 et (Maxwell)
     set(SM50FLAGS -gencode arch=compute_50,code=sm_50)
-    #SM3.7 = GK210 = K80 -- not currently used, since SM3.0 may be better
+    #SM3.7 = GK210 = K80 -- not currently used, since SM3.0 may be better (Kepler)
     set(SM37FLAGS -gencode arch=compute_37,code=sm_37)
-    #SM3.5 = GK110 + 110B = K20, K20X, K40, GTX780, GTX-Titan, GTX-Titan-Black, GTX-Titan-Z
+    #SM3.5 = GK110 + 110B = K20, K20X, K40, GTX780, GTX-Titan, GTX-Titan-Black, GTX-Titan-Z (Kepler)
     set(SM35FLAGS -gencode arch=compute_35,code=sm_35)
-    #SM3.0 = GK104 = K10, GTX680, 690 etc.
+    #SM3.0 = GK104 = K10, GTX680, 690 etc. (Kepler)
     set(SM30FLAGS -gencode arch=compute_30,code=sm_30)
 
     message(STATUS "CUDA version ${CUDA_VERSION} detected")
@@ -74,24 +74,31 @@ if(CUDA)
             set(DISABLE_OPTIMIZER_CONSTANTS TRUE)
 
 	elseif((${CUDA_VERSION} VERSION_EQUAL 11.0))
-	    message(STATUS "Configuring QUICK for SM3.5, SM5.0, SM6.0, SM7.0, SM7.5 and SM8.0")
-            list(APPEND CUDA_NVCC_FLAGS ${SM35FLAGS} ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS})
+	    message(STATUS "Configuring QUICK for SM3.0, SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5 and SM8.0")
+            list(APPEND CUDA_NVCC_FLAGS ${SM30FLAGS} ${SM35FLAGS} ${SM37FLAGS} ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS})
             list(APPEND CUDA_NVCC_FLAGS -DUSE_LEGACY_ATOMICS)
             set(DISABLE_OPTIMIZER_CONSTANTS TRUE)
 
 	elseif((${CUDA_VERSION} VERSION_GREATER_EQUAL 11.1) AND (${CUDA_VERSION} VERSION_LESS_EQUAL 11.7))
-	    message(STATUS "Configuring QUICK for SM3.5, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0 and SM8.6")
-            list(APPEND CUDA_NVCC_FLAGS ${SM35FLAGS} ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS} ${SM86FLAGS})
+	    message(STATUS "Configuring QUICK for SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0 and SM8.6")
+            list(APPEND CUDA_NVCC_FLAGS ${SM35FLAGS} ${SM37FLAGS} ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS} ${SM86FLAGS})
             list(APPEND CUDA_NVCC_FLAGS -DUSE_LEGACY_ATOMICS)
             set(DISABLE_OPTIMIZER_CONSTANTS TRUE)
-	    
-        elseif((${CUDA_VERSION} VERSION_GREATER_EQUAL 11.8) AND (${CUDA_VERSION} VERSION_LESS_EQUAL 12.0))
-            message(STATUS "Configuring QUICK for SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6, SM9.0")
-            list(APPEND CUDA_NVCC_FLAGS ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS} ${SM86FLAGS} ${SM90FLAGS})
+
+	elseif((${CUDA_VERSION} VERSION_EQUAL 11.8))
+            message(STATUS "Configuring QUICK for SM3.5, SM3.7, SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6, SM8.9, SM9.0")
+            list(APPEND CUDA_NVCC_FLAGS ${SM35FLAGS} ${SM37FLAGS} ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS} ${SM86FLAGS} ${SM89FLAGS} ${SM90FLAGS})
             list(APPEND CUDA_NVCC_FLAGS -DUSE_LEGACY_ATOMICS)
             set(DISABLE_OPTIMIZER_CONSTANTS TRUE)          
+	    
+	elseif((${CUDA_VERSION} VERSION_GREATER_EQUAL 12.0) AND (${CUDA_VERSION} VERSION_LESS_EQUAL 12.3))
+            message(STATUS "Configuring QUICK for SM5.0, SM6.0, SM7.0, SM7.5, SM8.0, SM8.6, SM8.9, SM9.0")
+            list(APPEND CUDA_NVCC_FLAGS ${SM50FLAGS} ${SM60FLAGS} ${SM70FLAGS} ${SM75FLAGS} ${SM80FLAGS} ${SM86FLAGS} ${SM89FLAGS} ${SM90FLAGS})
+            list(APPEND CUDA_NVCC_FLAGS -DUSE_LEGACY_ATOMICS)
+            set(DISABLE_OPTIMIZER_CONSTANTS TRUE)          
+
 	else()
-	    message(FATAL_ERROR "Error: Unsupported CUDA version. ${PROJECT_NAME} requires CUDA version >= 8.0 and <= 12.0.  Please upgrade your CUDA installation or disable building with CUDA.")
+	    message(FATAL_ERROR "Error: Unsupported CUDA version. ${PROJECT_NAME} requires CUDA version >= 8.0 and <= 12.3.  Please upgrade your CUDA installation or disable building with CUDA.")
 	endif()
 
     else()
@@ -144,6 +151,13 @@ if(CUDA)
             set(FOUND "TRUE")
         endif()
 
+        if("${QUICK_USER_ARCH}" MATCHES "adalovelace")
+            message(STATUS "Configuring QUICK for SM8.9")
+            list(APPEND CUDA_NVCC_FLAGS ${SM89FLAGS})
+            set(DISABLE_OPTIMIZER_CONSTANTS FALSE)
+            set(FOUND "TRUE")
+        endif()
+
         if("${QUICK_USER_ARCH}" MATCHES "hopper")
             message(STATUS "Configuring QUICK for SM9.0")
             list(APPEND CUDA_NVCC_FLAGS ${SM90FLAGS})
@@ -152,7 +166,7 @@ if(CUDA)
         endif()
 
         if (NOT ${FOUND})
-            message(FATAL_ERROR "Invalid value for QUICK_USER_ARCH. Possible values are kepler, maxwell, pascal, volta, turing, ampere and hopper.")
+            message(FATAL_ERROR "Invalid value for QUICK_USER_ARCH. Possible values are kepler, maxwell, pascal, volta, turing, ampere, adalovelace, and hopper.")
         endif()
 
     endif()
@@ -173,6 +187,11 @@ if(CUDA)
     list(APPEND CUDA_NVCC_FLAGS $<$<CONFIG:Debug>:-g>)
     if(QUICK_VERBOSE_PTXAS)
         list(APPEND CUDA_NVCC_FLAGS -Xptxas=-v)
+    endif()
+
+    # profiling flags
+    if(QUICK_PROFILE)
+        list(APPEND CUDA_NVCC_FLAGS --generate-line-info)
     endif()
 
     # extra CUDA flags


### PR DESCRIPTION
This PR updates the build systems for recent CUDA versions (12.3).

Also, build options for injecting compilation flags for developer profiling were added for convenience.

Closes #305, #311. 