### PR TITLE
Fix for issues 323 and 325

### DIFF
--- a/src/basis.f90
+++ b/src/basis.f90
@@ -636,10 +636,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
 
                            elseif (shell == 'F') then
                            quick_method%hasF=.true.
-#ifndef ENABLEF
-                           ierr=36 
-#endif
-
                            quick_basis%ktype(jshell) = 10
                            quick_basis%katom(jshell) = i
                            quick_basis%kstart(jshell) = jbasis
@@ -831,6 +827,13 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
       call MPI_BCAST(quick_method%hasF,1,mpi_logical,0,MPI_COMM_WORLD,mpierror)
    endif
    !======== END MPI/ALL NODES ================
+#endif
+
+#ifndef ENABLEF   
+   if(quick_method%hasF) then 
+       ierr=36
+       return
+   endif
 #endif
 
    ! Allocate the arrays now that we know the sizes

--- a/src/basis.f90
+++ b/src/basis.f90
@@ -58,7 +58,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
       atmbs=.true.
       atmbs2=.true.
       icont=0
-      quick_method%hasF=.true.
 
       ! parse the file and find the sizes of things to allocate them in memory
       do while (iofile  == 0 )
@@ -80,6 +79,7 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
             do while (iatom==0)
                read(ibasisfile,'(A80)',iostat=iofile) line
                read(line,*,iostat=iatom) shell,iprim,dnorm
+
                if (iatom == 0) then
                   quick_basis%kshell(iat) = quick_basis%kshell(iat) +1
                   !kcontract(iat) = kcontract(iat) + iprim
@@ -96,7 +96,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
                      kbasis(iat) = kbasis(iat) + 6
                      kcontract(iat) = kcontract(iat) + iprim * 6
                      elseif (shell == 'F') then
-                     quick_method%hasF=.false.
                      kbasis(iat) = kbasis(iat) + 10
                      kcontract(iat) = kcontract(iat) + iprim * 10
                   end if
@@ -158,7 +157,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
                                  kbasis(iat) = kbasis(iat) + 6
                                  kcontract(iat) = kcontract(iat) + iprim*6
                                  elseif (shell == 'F') then
-                                 quick_method%hasF=.false.
                                  kbasis(iat) = kbasis(iat) + 10
                                  kcontract(iat) = kcontract(iat) + iprim*10
                               end if
@@ -270,7 +268,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
       call MPI_BCAST(nshell,1,mpi_integer,0,MPI_COMM_WORLD,mpierror)
       call MPI_BCAST(nbasis,1,mpi_integer,0,MPI_COMM_WORLD,mpierror)
       call MPI_BCAST(nprim,1,mpi_integer,0,MPI_COMM_WORLD,mpierror)
-      call MPI_BCAST(quick_method%hasF,1,mpi_logical,0,MPI_COMM_WORLD,mpierror)
       call MPI_BARRIER(MPI_COMM_WORLD,mpierror)
    endif
 #endif
@@ -278,21 +275,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
    ! =============END MPI/ALL NODES=====================
 
    ! Allocate the arrays now that we know the sizes
-
-   if(quick_method%hasF)then
-      if(.not. allocated(Yxiao))        allocate(Yxiao(10000,56,56))
-      if(.not. allocated(Yxiaotemp))    allocate(Yxiaotemp(56,56,0:10))
-      if(.not. allocated(Yxiaoprim))    allocate(Yxiaoprim(MAXPRIM,MAXPRIM,56,56))
-      if(.not. allocated(attraxiao))    allocate(attraxiao(56,56,0:6))
-      if(.not. allocated(attraxiaoopt)) allocate(attraxiaoopt(3,56,56,0:5))
-   else
-      if(.not. allocated(Yxiao))        allocate(Yxiao(10000,120,120))
-      if(.not. allocated(Yxiaotemp))    allocate(Yxiaotemp(120,120,0:14))
-      if(.not. allocated(Yxiaoprim))    allocate(Yxiaoprim(MAXPRIM,MAXPRIM,120,120))
-      if(.not. allocated(attraxiao))    allocate(attraxiao(120,120,0:8))
-      if(.not. allocated(attraxiaoopt)) allocate(attraxiaoopt(3,120,120,0:7))
-   endif
-
    if(.not. allocated(Ycutoff)) allocate(Ycutoff(nshell,nshell))
    if(.not. allocated(cutmatrix)) allocate(cutmatrix(nshell,nshell))
    if(.not. allocated(aex)) allocate(aex(nprim ))
@@ -303,11 +285,6 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
    if(.not. allocated(gcg)) allocate(gcg(nprim ))
 
    ! initialize the array values to zero
-   Yxiao        = 0.0d0
-   Yxiaotemp    = 0.0d0
-   Yxiaoprim    = 0.0d0
-   attraxiao    = 0.0d0
-   attraxiaoopt = 0.0d0
    Ycutoff      = 0.0d0
    cutmatrix    = 0.0d0
    aex          = 0.0d0
@@ -405,6 +382,8 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
             quick_basis%Qfbasis(i,j) = 0
         enddo
    enddo
+
+   quick_method%hasF=.false.
 
    !====== MPI/MASTER ====================
    masterwork_readfile: if (master) then
@@ -656,7 +635,7 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
                            jshell = jshell+1
 
                            elseif (shell == 'F') then
-
+                           quick_method%hasF=.true.
 #ifndef ENABLEF
                            ierr=36 
 #endif
@@ -805,6 +784,7 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
                            enddo
                            jshell = jshell+1
                            elseif (shell == 'F') then
+                           quick_method%hasF=.true.
                            quick_basis%ktype(jshell) = 10
                            quick_basis%katom(jshell) = i
                            quick_basis%kstart(jshell) = jbasis
@@ -848,9 +828,31 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
    !======== MPI/ALL NODES ====================
    if (bMPI) then
       call MPI_BCAST(maxcontract,1,mpi_integer,0,MPI_COMM_WORLD,mpierror)
+      call MPI_BCAST(quick_method%hasF,1,mpi_logical,0,MPI_COMM_WORLD,mpierror)
    endif
    !======== END MPI/ALL NODES ================
 #endif
+
+   ! Allocate the arrays now that we know the sizes
+   if(.not. quick_method%hasF)then
+      if(.not. allocated(Yxiao))        allocate(Yxiao(10000,56,56))
+      if(.not. allocated(Yxiaotemp))    allocate(Yxiaotemp(56,56,0:10))
+      if(.not. allocated(Yxiaoprim))    allocate(Yxiaoprim(MAXPRIM,MAXPRIM,56,56))
+      if(.not. allocated(attraxiao))    allocate(attraxiao(56,56,0:6))
+      if(.not. allocated(attraxiaoopt)) allocate(attraxiaoopt(3,56,56,0:5))
+   else
+      if(.not. allocated(Yxiao))        allocate(Yxiao(10000,120,120))
+      if(.not. allocated(Yxiaotemp))    allocate(Yxiaotemp(120,120,0:14))
+      if(.not. allocated(Yxiaoprim))    allocate(Yxiaoprim(MAXPRIM,MAXPRIM,120,120))
+      if(.not. allocated(attraxiao))    allocate(attraxiao(120,120,0:8))
+      if(.not. allocated(attraxiaoopt)) allocate(attraxiaoopt(3,120,120,0:7))
+   endif
+
+   Yxiao        = 0.0d0
+   Yxiaotemp    = 0.0d0
+   Yxiaoprim    = 0.0d0
+   attraxiao    = 0.0d0
+   attraxiaoopt = 0.0d0
 
    if(.not. allocated(aexp)) allocate(aexp(maxcontract,nbasis))
 

--- a/src/cuda/gpu_get2e_getxc_drivers.h
+++ b/src/cuda/gpu_get2e_getxc_drivers.h
@@ -160,13 +160,17 @@ extern "C" void gpu_get_cshell_eri_grad_(QUICKDouble* grad)
         getGrad(gpu);
     }
 
-    upload_sim_to_constant_ffff(gpu);
-
-    if(gpu -> gpu_sim.is_oshell == true){
-        get_oshell_eri_grad_ffff(gpu);
-    }else{
-        getGrad_ffff(gpu);
+#ifdef CUDA_SPDF
+    if (gpu->maxL >= 3) {
+        upload_sim_to_constant_ffff(gpu);
+       
+        if(gpu -> gpu_sim.is_oshell == true){
+            get_oshell_eri_grad_ffff(gpu);
+        }else{
+            getGrad_ffff(gpu);
+        }
     }
+#endif
 
     PRINTDEBUG("COMPLETE KERNEL")
 

--- a/src/cuda/gpu_get2e_grad_ffff.cuh
+++ b/src/cuda/gpu_get2e_grad_ffff.cuh
@@ -1699,6 +1699,7 @@ if(bprint){
 #endif    
    
 #ifdef USE_LEGACY_ATOMICS 
+/*
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart], AGradx);
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart + 1], AGrady);
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart + 2], AGradz);
@@ -1717,6 +1718,7 @@ if(bprint){
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart], (-AGradx-BGradx-CGradx));
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart + 1], (-AGrady-BGrady-CGrady));
     GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart + 2], (-AGradz-BGradz-CGradz));
+*/
 #else 
     atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart], AGradx);
     atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart + 1], AGrady);

--- a/src/modules/include/gradient.fh
+++ b/src/modules/include/gradient.fh
@@ -591,7 +591,7 @@ contains
         call gpu_upload_beta_density_matrix(quick_qm_struct%denseb)
 #endif
 
-        if(quick_method%hasF) then
+        if(.not. quick_method%hasF) then
           call gpu_get_oei_grad(quick_qm_struct%gradient,quick_qm_struct%ptchg_gradient)
         else
 

--- a/src/modules/quick_oei_module.f90
+++ b/src/modules/quick_oei_module.f90
@@ -111,7 +111,7 @@ subroutine get1e(deltaO)
          RECORD_TIME(timer_begin%T1eV)
 
 #if defined CUDA || defined HIP
-         if(quick_method%hasF) then
+         if(.not. quick_method%hasF) then
            call gpu_get_oei(quick_qm_struct%o)
          else
 
@@ -197,7 +197,7 @@ subroutine get1e(deltaO)
       RECORD_TIME(timer_begin%T1eV)
 
 #if defined CUDA_MPIV || defined HIP_MPIV
-      if(quick_method%hasF) then
+      if(.not. quick_method%hasF) then
         call gpu_get_oei(quick_qm_struct%o)
       else
         do i=1,mpi_jshelln(mpirank)

--- a/tools/runtest
+++ b/tools/runtest
@@ -264,7 +264,7 @@ print_test_info(){
     ene_psb3_blyp_631gss)                 testinfo="PSB3: DFT energy test: s, p and d basis functions, BLYP functional";;
     ene_psb3_b3lyp_631g)                  testinfo="PSB3: DFT energy test: s and p basis functions, native B3LYP functional";;
     ene_psb3_b3lyp_631gss)                testinfo="PSB3: DFT energy test: s, p and d basis functions, native B3LYP functional";;
-    ene_C2H6_b3lyp_def2tzvp)              testinfo="PSB3: DFT energy test: s, p, d and f basis functions, native B3LYP functional";;
+    ene_C2H6_b3lyp_def2tzvp)              testinfo="C2H6: DFT energy test: s, p, d and f basis functions, native B3LYP functional";;
     ene_psb3_libxc_lda_631g)              testinfo="PSB3: DFT energy test: s and p basis functions, libxc LDA functional";;
     ene_psb3_libxc_gga_631g)              testinfo="PSB3: DFT energy test: s and p basis functions, libxc GGA functional";;
     ene_psb3_libxc_hgga_631g)             testinfo="PSB3: DFT energy test: s and p basis functions, libxc hybrid GGA functional";;


### PR DESCRIPTION
The enclosed changes fix the segfault in cEW-enabled QM/MM and OEI gradient timing (resolves #323, resolves #325). There was a bug associated with the flag that indicates the availability of F functions. As a result, OEI potential and gradients were computed on the host and the point charge gradient vector wasn't uploaded to the GPU. This caused the segfault. Please check and merge. I will proceed with other issues when this is merged into the master branch. 