### PR TITLE
F trap for cEW enabled QM/MM

### DIFF
--- a/src/basis.f90
+++ b/src/basis.f90
@@ -15,6 +15,11 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
    use allmod
    use quick_gridpoints_module
    use quick_exception_module
+
+#ifdef CEW
+   use quick_cew_module, only: quick_cew
+#endif
+
    !
    implicit double precision(a-h,o-z)
    character(len=120) :: line
@@ -832,6 +837,13 @@ subroutine readbasis(natomxiao,natomstart,natomfinal,nbasisstart,nbasisfinal,ier
 #ifndef ENABLEF   
    if(quick_method%hasF) then 
        ierr=36
+       return
+   endif
+#endif
+
+#ifdef CEW
+   if(quick_method%hasF .and. quick_cew%use_cew) then
+       ierr=38
        return
    endif
 #endif

--- a/src/modules/quick_exception_module.f90
+++ b/src/modules/quick_exception_module.f90
@@ -132,7 +132,10 @@ contains
 
     case(37)
       msg='G functions are not supported. Please choose a different basis set.'
-      
+
+    case(38)
+      msg='Support for F functions is currently not available in cEW-enabled QM/MM.'      
+
     case default
       msg='Unknown error.'
 


### PR DESCRIPTION
I have implemented a trap for F functions if the user tries to run cEW-enabled QM/MM with high angular momentum basis sets. This resolves #329. Please test and merge. 