### PR TITLE
Support for legacy atomics in cuda f gradient kernels

### DIFF
--- a/src/cuda/gpu_common.h
+++ b/src/cuda/gpu_common.h
@@ -189,6 +189,11 @@ if (error != cudaSuccess && error != cudaErrorNotReady)\
 typedef float  QUICKSingle;
 #define QUICKULL \
 unsigned long long int
+#ifdef USE_LEGACY_ATOMICS
+#define QUICKAtomicType unsigned long long int
+#else
+#define QUICKAtomicType double
+#endif
 
 /* 
  ****************************************************************

--- a/src/cuda/gpu_get2e_grad_ffff.cu
+++ b/src/cuda/gpu_get2e_grad_ffff.cu
@@ -65,7 +65,7 @@ texture <int2, cudaTextureType1D, cudaReadModeElementType> tex_Xcoeff;
 #define ERI_GRAD_FFFF_SMEM_INT_SIZE 7
 #define ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE 10
 #define ERI_GRAD_FFFF_SMEM_DBL_SIZE 3
-#define ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE 20
+#define ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE 19
 #define ERI_GRAD_FFFF_SMEM_CHAR_SIZE 512
 #define ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE 2
 #define ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE 1
@@ -92,19 +92,18 @@ texture <int2, cudaTextureType1D, cudaReadModeElementType> tex_Xcoeff;
 #define DEV_SIM_DBL_PTR_DENSEB smem_dbl_ptr[ERI_GRAD_FFFF_TPB*4+threadIdx.x]
 #define DEV_SIM_DBL_PTR_EXPOSUM smem_dbl_ptr[ERI_GRAD_FFFF_TPB*5+threadIdx.x]
 #define DEV_SIM_DBL_PTR_GCEXPO smem_dbl_ptr[ERI_GRAD_FFFF_TPB*6+threadIdx.x]
-#define DEV_SIM_DBL_PTR_GRAD smem_dbl_ptr[ERI_GRAD_FFFF_TPB*7+threadIdx.x]
-#define DEV_SIM_DBL_PTR_STORE smem_dbl_ptr[ERI_GRAD_FFFF_TPB*8+threadIdx.x]
-#define DEV_SIM_DBL_PTR_STORE2 smem_dbl_ptr[ERI_GRAD_FFFF_TPB*9+threadIdx.x]
-#define DEV_SIM_DBL_PTR_STOREAA smem_dbl_ptr[ERI_GRAD_FFFF_TPB*10+threadIdx.x]
-#define DEV_SIM_DBL_PTR_STOREBB smem_dbl_ptr[ERI_GRAD_FFFF_TPB*11+threadIdx.x]
-#define DEV_SIM_DBL_PTR_STORECC smem_dbl_ptr[ERI_GRAD_FFFF_TPB*12+threadIdx.x]
-#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERX smem_dbl_ptr[ERI_GRAD_FFFF_TPB*13+threadIdx.x]
-#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERY smem_dbl_ptr[ERI_GRAD_FFFF_TPB*14+threadIdx.x]
-#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERZ smem_dbl_ptr[ERI_GRAD_FFFF_TPB*15+threadIdx.x]
-#define DEV_SIM_DBL_PTR_XCOEFF smem_dbl_ptr[ERI_GRAD_FFFF_TPB*16+threadIdx.x]
-#define DEV_SIM_DBL_PTR_XYZ smem_dbl_ptr[ERI_GRAD_FFFF_TPB*17+threadIdx.x]
-#define DEV_SIM_DBL_PTR_YCUTOFF smem_dbl_ptr[ERI_GRAD_FFFF_TPB*18+threadIdx.x]
-#define DEV_SIM_DBL_PTR_YVERTICALTEMP smem_dbl_ptr[ERI_GRAD_FFFF_TPB*19+threadIdx.x]
+#define DEV_SIM_DBL_PTR_STORE smem_dbl_ptr[ERI_GRAD_FFFF_TPB*7+threadIdx.x]
+#define DEV_SIM_DBL_PTR_STORE2 smem_dbl_ptr[ERI_GRAD_FFFF_TPB*8+threadIdx.x]
+#define DEV_SIM_DBL_PTR_STOREAA smem_dbl_ptr[ERI_GRAD_FFFF_TPB*9+threadIdx.x]
+#define DEV_SIM_DBL_PTR_STOREBB smem_dbl_ptr[ERI_GRAD_FFFF_TPB*10+threadIdx.x]
+#define DEV_SIM_DBL_PTR_STORECC smem_dbl_ptr[ERI_GRAD_FFFF_TPB*11+threadIdx.x]
+#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERX smem_dbl_ptr[ERI_GRAD_FFFF_TPB*12+threadIdx.x]
+#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERY smem_dbl_ptr[ERI_GRAD_FFFF_TPB*13+threadIdx.x]
+#define DEV_SIM_DBL_PTR_WEIGHTEDCENTERZ smem_dbl_ptr[ERI_GRAD_FFFF_TPB*14+threadIdx.x]
+#define DEV_SIM_DBL_PTR_XCOEFF smem_dbl_ptr[ERI_GRAD_FFFF_TPB*15+threadIdx.x]
+#define DEV_SIM_DBL_PTR_XYZ smem_dbl_ptr[ERI_GRAD_FFFF_TPB*16+threadIdx.x]
+#define DEV_SIM_DBL_PTR_YCUTOFF smem_dbl_ptr[ERI_GRAD_FFFF_TPB*17+threadIdx.x]
+#define DEV_SIM_DBL_PTR_YVERTICALTEMP smem_dbl_ptr[ERI_GRAD_FFFF_TPB*18+threadIdx.x]
 #define DEV_SIM_DBL_PRIMLIMIT smem_dbl[ERI_GRAD_FFFF_TPB*0+threadIdx.x]
 #define DEV_SIM_DBL_GRADCUTOFF smem_dbl[ERI_GRAD_FFFF_TPB*1+threadIdx.x]
 #define DEV_SIM_DBL_HYB_COEFF smem_dbl[ERI_GRAD_FFFF_TPB*2+threadIdx.x]
@@ -376,7 +375,7 @@ void getGrad_ffff(_gpu_type gpu)
        QUICKDouble **dbl_ptr_buffer = (QUICKDouble**) malloc(ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKDouble*));
        int2 **int2_ptr_buffer = (int2**) malloc(ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int2*));
        unsigned char **char_ptr_buffer = (unsigned char**) malloc(ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned char*));
-       QUICKULL **ull_ptr_buffer = (QUICKULL**) malloc(ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKULL*));
+       QUICKAtomicType **ull_ptr_buffer = (QUICKAtomicType**) malloc(ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
        unsigned char trans[TRANSDIM*TRANSDIM*TRANSDIM];
 
 //printf("Storing data \n");
@@ -410,23 +409,26 @@ void getGrad_ffff(_gpu_type gpu)
        dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*4+i] = gpu->gpu_sim.denseb;
        dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*5+i] = gpu->gpu_sim.expoSum;
        dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*6+i] = gpu->gpu_sim.gcexpo;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*7+i] = gpu->gpu_sim.grad;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*8+i] = gpu->gpu_sim.store;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*9+i] = gpu->gpu_sim.store2;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*10+i] = gpu->gpu_sim.storeAA;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*11+i] = gpu->gpu_sim.storeBB;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*12+i] = gpu->gpu_sim.storeCC;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*13+i] = gpu->gpu_sim.weightedCenterX;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*14+i] = gpu->gpu_sim.weightedCenterY;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*15+i] = gpu->gpu_sim.weightedCenterZ;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*16+i] = gpu->gpu_sim.Xcoeff;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*17+i] = gpu->gpu_sim.xyz;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*18+i] = gpu->gpu_sim.YCutoff;
-       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*19+i] = gpu->gpu_sim.YVerticalTemp;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*7+i] = gpu->gpu_sim.store;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*8+i] = gpu->gpu_sim.store2;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*9+i] = gpu->gpu_sim.storeAA;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*10+i] = gpu->gpu_sim.storeBB;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*11+i] = gpu->gpu_sim.storeCC;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*12+i] = gpu->gpu_sim.weightedCenterX;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*13+i] = gpu->gpu_sim.weightedCenterY;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*14+i] = gpu->gpu_sim.weightedCenterZ;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*15+i] = gpu->gpu_sim.Xcoeff;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*16+i] = gpu->gpu_sim.xyz;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*17+i] = gpu->gpu_sim.YCutoff;
+       dbl_ptr_buffer[ERI_GRAD_FFFF_TPB*18+i] = gpu->gpu_sim.YVerticalTemp;
        int2_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.sorted_YCutoffIJ;
        char_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.mpi_bcompute;
        char_ptr_buffer[ERI_GRAD_FFFF_TPB*1+i] = gpu->gpu_sim.KLMN;
+#ifdef USE_LEGACY_ATOMICS 
        ull_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.gradULL;
+#else
+       ull_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.grad;
+#endif
        }
 
 
@@ -568,7 +570,7 @@ char));
        int2 **dev_int2_ptr_buffer;
        unsigned char **dev_char_ptr_buffer;
        unsigned char *dev_char_buffer;
-       QUICKULL **dev_ull_ptr_buffer;
+       QUICKAtomicType **dev_ull_ptr_buffer;
 
        cudaMalloc((void **)&dev_int_buffer, ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int));
 //printf("Allocating int ptr device memory %d %d %d %d %d %d\n", sizeof(int), sizeof(int*), sizeof(QUICKDouble), sizeof(QUICKDouble*),
@@ -580,7 +582,7 @@ char));
        cudaMalloc((void **)&dev_int2_ptr_buffer, ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int2*));
        cudaMalloc((void **)&dev_char_ptr_buffer, ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned char*));
        cudaMalloc((void **)&dev_char_buffer, ERI_GRAD_FFFF_SMEM_CHAR_SIZE*sizeof(unsigned char));
-       cudaMalloc((void **)&dev_ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKULL*));
+       cudaMalloc((void **)&dev_ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
 
 //printf("Uploading data \n");
 
@@ -592,7 +594,7 @@ char));
        cudaMemcpy(dev_char_ptr_buffer, char_ptr_buffer, ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned
 char*), cudaMemcpyHostToDevice);
        cudaMemcpy(dev_char_buffer, &trans, ERI_GRAD_FFFF_SMEM_CHAR_SIZE*sizeof(unsigned char), cudaMemcpyHostToDevice);
-       cudaMemcpy(dev_ull_ptr_buffer, ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKULL*),
+       cudaMemcpy(dev_ull_ptr_buffer, ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*),
 cudaMemcpyHostToDevice);
 
 /*
@@ -623,7 +625,7 @@ sizeof(int)*ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(QUICKDouble)*ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB+sizeof(QUICKDouble*)*ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(int*)*ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(int2*)*ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned
 char*)*ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned char)*ERI_GRAD_FFFF_SMEM_CHAR_SIZE+
- sizeof(QUICKULL*)*ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB>>>(dev_int_buffer,
+ sizeof(QUICKAtomicType*)*ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB>>>(dev_int_buffer,
 dev_int_ptr_buffer, dev_dbl_buffer, dev_dbl_ptr_buffer, dev_int2_ptr_buffer, dev_char_ptr_buffer, dev_char_buffer,
 dev_ull_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
 

--- a/src/cuda/gpu_get2e_grad_ffff.cu
+++ b/src/cuda/gpu_get2e_grad_ffff.cu
@@ -70,7 +70,7 @@ texture <int2, cudaTextureType1D, cudaReadModeElementType> tex_Xcoeff;
 #define ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE 2
 #define ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE 1
 
-#define ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE 1
+#define ERI_GRAD_FFFF_SMEM_PTR_SIZE 1
 
 #define DEV_SIM_INT_PTR_KATOM smem_int_ptr[ERI_GRAD_FFFF_TPB*0+threadIdx.x]
 #define DEV_SIM_INT_PTR_KPRIM smem_int_ptr[ERI_GRAD_FFFF_TPB*1+threadIdx.x]
@@ -115,7 +115,7 @@ texture <int2, cudaTextureType1D, cudaReadModeElementType> tex_Xcoeff;
 #define DEV_SIM_INT_PRIM_TOTAL smem_int[ERI_GRAD_FFFF_TPB*5+threadIdx.x]
 #define DEV_SIM_INT_FFSTART smem_int[ERI_GRAD_FFFF_TPB*6+threadIdx.x]
 
-#define DEV_SIM_ULL_PTR_GRAD smem_ull_ptr[ERI_GRAD_FFFF_TPB*0+threadIdx.x]
+#define DEV_SIM_PTR_GRAD smem_grad_ptr[ERI_GRAD_FFFF_TPB*0+threadIdx.x]
 
 #define LOCTRANS(A,i1,i2,i3,d1,d2,d3) A[(i3+((i2)+(i1)*(d2))*(d3))*ERI_GRAD_FFFF_TPB+threadIdx.x]
 #define DEV_SIM_CHAR_TRANS smem_char
@@ -147,71 +147,6 @@ texture <int2, cudaTextureType1D, cudaReadModeElementType> tex_Xcoeff;
 static float totTime;
 #endif
 
-/*
-void uploadDevSimToSmem_ffff(_gpu_type gpu ){
-
-       cuda_buffer_type<int>* int_buffer = new cuda_buffer_type<int>(ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<int*>* int_ptr_buffer = new cuda_buffer_type<int*>(ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<QUICKDouble>* dbl_buffer = new cuda_buffer_type<QUICKDouble>(ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<QUICKDouble*>* dbl_ptr_buffer = new cuda_buffer_type<QUICKDouble*>(ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB);       
-       cuda_buffer_type<int2*>* int2_ptr_buffer = new cuda_buffer_type<int2*>(ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<char*>* char_ptr_buffer = new cuda_buffer_type<char*>(ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-
-       for(int i=0; i<ERI_GRAD_FFFF_TPB; i++){
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.natom;
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*1+i] = &gpu->gpu_sim.nbasis;
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*2+i] = &gpu->gpu_sim.nshell;
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*3+i] = &gpu->gpu_sim.jbasis;
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*4+i] = &gpu->gpu_sim.sqrQshell;
-           int_buffer->_hostData[ERI_GRAD_FFFF_TPB*5+i] = &gpu->gpu_sim.prim_total;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.katom;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*1+i] = &gpu->gpu_sim.KLMN;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*2+i] = &gpu->gpu_sim.kprim;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*3+i] = &gpu->gpu_sim.kstart;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*4+i] = &gpu->gpu_sim.Ksumtype;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*5+i] = &gpu->gpu_sim.prim_start;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*6+i] = &gpu->gpu_sim.Qfbasis;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*7+i] = &gpu->gpu_sim.Qsbasis;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*8+i] = &gpu->gpu_sim.Qstart;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*9+i] = &gpu->gpu_sim.sorted_Q;
-           int_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*10+i] = &gpu->gpu_sim.sorted_Qnumber;
-           dbl_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.primLimit;
-           dbl_buffer->_hostData[ERI_GRAD_FFFF_TPB*1+i] = &gpu->gpu_sim.gradCutoff;
-           dbl_buffer->_hostData[ERI_GRAD_FFFF_TPB*2+i] = &gpu->gpu_sim.hyb_coeff;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.cons;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*1+i] = &gpu->gpu_sim.cutMatrix;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*2+i] = &gpu->gpu_sim.cutPrim;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*3+i] = &gpu->gpu_sim.dense;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*4+i] = &gpu->gpu_sim.denseb;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*5+i] = &gpu->gpu_sim.expoSum;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*6+i] = &gpu->gpu_sim.gcexpo;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*7+i] = &gpu->gpu_sim.grad;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*8+i] = &gpu->gpu_sim.gradULL;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*9+i] = &gpu->gpu_sim.store;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*10+i] = &gpu->gpu_sim.store2;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*11+i] = &gpu->gpu_sim.storeAA;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*12+i] = &gpu->gpu_sim.storeBB;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*13+i] = &gpu->gpu_sim.storeCC;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*14+i] = &gpu->gpu_sim.weightedCenterX;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*15+i] = &gpu->gpu_sim.weightedCenterY;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*16+i] = &gpu->gpu_sim.weightedCenterZ;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*17+i] = &gpu->gpu_sim.Xcoeff;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*18+i] = &gpu->gpu_sim.xyz;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*19+i] = &gpu->gpu_sim.YCutoff;
-           dbl_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*20+i] = &gpu->gpu_sim.YVerticalTemp;
-           int2_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.sorted_YCutoffIJ;
-           char_ptr_buffer->_hostData[ERI_GRAD_FFFF_TPB*0+i] = &gpu->gpu_sim.mpi_bcompute;
-       }
-
-       int_buffer -> Upload();
-       int_ptr_buffer -> Upload();
-       dbl_buffer -> Upload();
-       dbl_ptr_buffer -> Upload();
-       int2_ptr_buffer -> Upload();
-       char_ptr_buffer -> Upload();
-
-}
-*/
 
 struct Partial_ERI{
     int YCutoffIJ_x;
@@ -231,9 +166,6 @@ bool ComparePrimNum(Partial_ERI p1, Partial_ERI p2){
 
 void ResortERIs(_gpu_type gpu){
 
-    //cuda_buffer_type<int2>* resorted_YCutoffIJ = new cuda_buffer_type<int2>(gpu->gpu_cutoff->sqrQshell);
-    //cuda_buffer_type<int> *resorted_Qnumber = new cuda_buffer_type<int2>(gpu->gpu_basis->Qshell);
-    //cuda_buffer_type<int> *resorted_Q = new cuda_buffer_type<int2>(gpu->gpu_basis->Qshell);
     int2 eri_type_order[]={{0,0},{0,1},{1,0},{1,1},{0,2},{2,0},{1,2},{2,1},{0,3},{3,0},{2,2},{1,3},{3,1},
                           {2,3},{3,2},{3,3}};
     unsigned char eri_type_order_map[]={0,1,3,6,10,13,15,16};
@@ -242,8 +174,6 @@ void ResortERIs(_gpu_type gpu){
     bool ffset= false;
 
     // Step 1: sort according sum of angular momentum of a partial ERI. (ie. i+j of <ij| ). 
-
-
     // Step 2: sort according to type order specified in eri_type_order array. This ensures that eri vector follows the order we
     // want. 
      
@@ -271,14 +201,8 @@ lbl_t.y){
     }
 
     eri_type_block_map[idx2]=idx1;
-    
-    //memcpy(gpu->gpu_cutoff->sorted_YCutoffIJ ->_hostData,resorted_YCutoffIJ,gpu->gpu_cutoff->sqrQshell*sizeof(int2));
 
-
-//    printf("ffStart %d \n", ffStart);
     for(int i=0; i<gpu->gpu_cutoff->sqrQshell; i++){
-//        printf("i j q1 q2 %d %d %d %d \n", resorted_YCutoffIJ[i].x, resorted_YCutoffIJ[i].y, gpu->gpu_basis->sorted_Qnumber->_hostData[resorted_YCutoffIJ[i].x], gpu->gpu_basis->sorted_Qnumber->_hostData[resorted_YCutoffIJ[i].y]);
-
         gpu->gpu_cutoff->sorted_YCutoffIJ ->_hostData[i].x=resorted_YCutoffIJ[i].x;
         gpu->gpu_cutoff->sorted_YCutoffIJ ->_hostData[i].y=resorted_YCutoffIJ[i].y;
         
@@ -310,44 +234,16 @@ lbl_t.y){
                           kprim_score};
     }
 
-/*
-    for(int i=0; i<17;i++)
-        printf("eri_type_block_map[%d] \n", eri_type_block_map[i]);
-*/
-/*
-    for(int i=0; i<gpu->gpu_cutoff->sqrQshell; i++){
-        printf("Test i j q1 q2 %d %d %d %d %d %d \n", partial_eris[i].YCutoffIJ_x, partial_eris[i].YCutoffIJ_y,
-
-partial_eris[i].Qnumber_x,\
-        partial_eris[i].Qnumber_y, partial_eris[i].kprim_x, partial_eris[i].kprim_y);
-    }
-*/
-
-//fflush(stdout);
-
-//        std::sort(partial_eris,partial_eris+100,ComparePrimNum);
 
     for(int i=0; i<16;i++){
-//        printf("Sorting: %d %d \n",eri_type_block_map[i], eri_type_block_map[i+1]);
-//fflush(stdout);
         std::sort(partial_eris+eri_type_block_map[i],partial_eris+eri_type_block_map[i+1],ComparePrimNum);
     }
 
     for(int i=0; i<gpu->gpu_cutoff->sqrQshell; i++){
-//        printf("i j q1 q2 %d %d %d %d %d %d \n", partial_eris[i].YCutoffIJ_x, partial_eris[i].YCutoffIJ_y, partial_eris[i].Qnumber_x,\
-        partial_eris[i].Qnumber_y, partial_eris[i].kprim_x, partial_eris[i].kprim_y);
         gpu->gpu_cutoff->sorted_YCutoffIJ ->_hostData[i].x = partial_eris[i].YCutoffIJ_x;
         gpu->gpu_cutoff->sorted_YCutoffIJ ->_hostData[i].y = partial_eris[i].YCutoffIJ_y;
-
     }
 
-
-//    for(int i=0; i<17;i++)
-//        printf("eri_type_block_map[%d] \n", eri_type_block_map[i]);
-
-//    printf("ffStart %d \n", ffStart);
-
-//    gpu -> gpu_cutoff -> sorted_YCutoffIJ -> DeleteGPU();
     gpu -> gpu_cutoff -> sorted_YCutoffIJ  -> Upload();    
     gpu -> gpu_sim.sorted_YCutoffIJ = gpu -> gpu_cutoff -> sorted_YCutoffIJ  -> _devData;
     gpu -> gpu_sim.ffStart = ffStart;
@@ -357,15 +253,6 @@ partial_eris[i].Qnumber_x,\
 void getGrad_ffff(_gpu_type gpu)
 {
 
-//printf("Allocating ffff memory \n");
-/*
-       cuda_buffer_type<int>* int_buffer = new cuda_buffer_type<int>(ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<int*>* int_ptr_buffer = new cuda_buffer_type<int*>(ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<QUICKDouble>* dbl_buffer = new cuda_buffer_type<QUICKDouble>(ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<QUICKDouble*>* dbl_ptr_buffer = new  cuda_buffer_type<QUICKDouble*>(ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB);    
-       cuda_buffer_type<int2*>* int2_ptr_buffer = new cuda_buffer_type<int2*>(ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-       cuda_buffer_type<unsigned char*>* char_ptr_buffer = new cuda_buffer_type<unsigned char*>(ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB);
-*/
 
        ResortERIs(gpu);
 
@@ -375,11 +262,9 @@ void getGrad_ffff(_gpu_type gpu)
        QUICKDouble **dbl_ptr_buffer = (QUICKDouble**) malloc(ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKDouble*));
        int2 **int2_ptr_buffer = (int2**) malloc(ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int2*));
        unsigned char **char_ptr_buffer = (unsigned char**) malloc(ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned char*));
-       QUICKAtomicType **ull_ptr_buffer = (QUICKAtomicType**) malloc(ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
+       QUICKAtomicType **grad_ptr_buffer = (QUICKAtomicType**) malloc(ERI_GRAD_FFFF_SMEM_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
        unsigned char trans[TRANSDIM*TRANSDIM*TRANSDIM];
 
-//printf("Storing data \n");
-//printf("ffStart: %d \n", gpu->gpu_sim.ffStart);
 
        for(int i=0; i<ERI_GRAD_FFFF_TPB; i++){
        int_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.natom;
@@ -425,9 +310,9 @@ void getGrad_ffff(_gpu_type gpu)
        char_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.mpi_bcompute;
        char_ptr_buffer[ERI_GRAD_FFFF_TPB*1+i] = gpu->gpu_sim.KLMN;
 #ifdef USE_LEGACY_ATOMICS 
-       ull_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.gradULL;
+       grad_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.gradULL;
 #else
-       ull_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.grad;
+       grad_ptr_buffer[ERI_GRAD_FFFF_TPB*0+i] = gpu->gpu_sim.grad;
 #endif
        }
 
@@ -553,15 +438,6 @@ void getGrad_ffff(_gpu_type gpu)
         LOC3(trans, 6, 1, 0, TRANSDIM, TRANSDIM, TRANSDIM) = 105;
         LOC3(trans, 7, 0, 0, TRANSDIM, TRANSDIM, TRANSDIM) = 118;
 
-/*
-       unsigned char *trans_buffer = (unsigned char*) malloc(ERI_GRAD_FFFF_SMEM_CHAR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned
-char));
-
-       for(int j=0;j<ERI_GRAD_FFFF_SMEM_CHAR_SIZE;j++)
-           for(int i=0;i<ERI_GRAD_FFFF_TPB;i++)
-               trans_buffer[j*ERI_GRAD_FFFF_TPB+i]=trans[j];
-*/
-//printf("Allocating device memory \n");
 
        int *dev_int_buffer;
        int **dev_int_ptr_buffer;
@@ -570,21 +446,17 @@ char));
        int2 **dev_int2_ptr_buffer;
        unsigned char **dev_char_ptr_buffer;
        unsigned char *dev_char_buffer;
-       QUICKAtomicType **dev_ull_ptr_buffer;
+       QUICKAtomicType **dev_grad_ptr_buffer;
 
        cudaMalloc((void **)&dev_int_buffer, ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int));
-//printf("Allocating int ptr device memory %d %d %d %d %d %d\n", sizeof(int), sizeof(int*), sizeof(QUICKDouble), sizeof(QUICKDouble*),
-//sizeof(int2*), sizeof(unsigned char*));
        cudaMalloc((void **)&dev_int_ptr_buffer, ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int*));
-//printf("Allocating dbl device memory \n");
        cudaMalloc((void **)&dev_dbl_buffer, ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKDouble));
        cudaMalloc((void **)&dev_dbl_ptr_buffer, ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKDouble*));
        cudaMalloc((void **)&dev_int2_ptr_buffer, ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int2*));
        cudaMalloc((void **)&dev_char_ptr_buffer, ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned char*));
        cudaMalloc((void **)&dev_char_buffer, ERI_GRAD_FFFF_SMEM_CHAR_SIZE*sizeof(unsigned char));
-       cudaMalloc((void **)&dev_ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
+       cudaMalloc((void **)&dev_grad_ptr_buffer, ERI_GRAD_FFFF_SMEM_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*));
 
-//printf("Uploading data \n");
 
        cudaMemcpy(dev_int_buffer, int_buffer, ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int), cudaMemcpyHostToDevice);
        cudaMemcpy(dev_int_ptr_buffer, int_ptr_buffer, ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(int*), cudaMemcpyHostToDevice);
@@ -594,49 +466,26 @@ char));
        cudaMemcpy(dev_char_ptr_buffer, char_ptr_buffer, ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(unsigned
 char*), cudaMemcpyHostToDevice);
        cudaMemcpy(dev_char_buffer, &trans, ERI_GRAD_FFFF_SMEM_CHAR_SIZE*sizeof(unsigned char), cudaMemcpyHostToDevice);
-       cudaMemcpy(dev_ull_ptr_buffer, ull_ptr_buffer, ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*),
+       cudaMemcpy(dev_grad_ptr_buffer, grad_ptr_buffer, ERI_GRAD_FFFF_SMEM_PTR_SIZE*ERI_GRAD_FFFF_TPB*sizeof(QUICKAtomicType*),
 cudaMemcpyHostToDevice);
 
-/*
-       int_buffer -> Upload();
-       int_ptr_buffer -> Upload();
-       dbl_buffer -> Upload();
-       dbl_ptr_buffer -> Upload();
-       int2_ptr_buffer -> Upload();
-       char_ptr_buffer -> Upload();
-*/
-//printf("Launching ffff \n");
-
-//   nvtxRangePushA("Gradient 2e");
-    
         if (gpu->maxL >= 3) {
         // Part f-3
 #ifdef CUDA_SPDF
-
-//printf("smem required: %d \n", (int)(sizeof(int)*ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB+
-//            sizeof(QUICKDouble)*ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB+sizeof(QUICKDouble*)*ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(int*)*ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB+
-//            sizeof(int2*)*ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned
-//char*)*ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned
-//char)*ERI_GRAD_FFFF_SMEM_CHAR_SIZE)/1024);
-
-            //printf("calling getGrad_kernel_spdf4 \n");
             QUICK_SAFE_CALL((getGrad_kernel_ffff<<<gpu->blocks*ERI_GRAD_FFFF_BPSM, ERI_GRAD_FFFF_TPB,
 sizeof(int)*ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(QUICKDouble)*ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB+sizeof(QUICKDouble*)*ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(int*)*ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(int2*)*ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned
 char*)*ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned char)*ERI_GRAD_FFFF_SMEM_CHAR_SIZE+
- sizeof(QUICKAtomicType*)*ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB>>>(dev_int_buffer,
+ sizeof(QUICKAtomicType*)*ERI_GRAD_FFFF_SMEM_PTR_SIZE*ERI_GRAD_FFFF_TPB>>>(dev_int_buffer,
 dev_int_ptr_buffer, dev_dbl_buffer, dev_dbl_ptr_buffer, dev_int2_ptr_buffer, dev_char_ptr_buffer, dev_char_buffer,
-dev_ull_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
+dev_grad_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
 
 #endif  
         }
 
     cudaDeviceSynchronize();
 
-//    nvtxRangePop();
-
-//printf("Deleting data \n");
 
    free(int_buffer);
    free(int_ptr_buffer);
@@ -644,8 +493,7 @@ dev_ull_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
    free(dbl_ptr_buffer);
    free(int2_ptr_buffer);
    free(char_ptr_buffer);
-   free(ull_ptr_buffer);
-//   free(trans_buffer);
+   free(grad_ptr_buffer);
 
    cudaFree(dev_int_buffer);
    cudaFree(dev_int_ptr_buffer);
@@ -654,15 +502,7 @@ dev_ull_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
    cudaFree(dev_int2_ptr_buffer);
    cudaFree(dev_char_ptr_buffer);
    cudaFree(dev_char_buffer);
-   cudaFree(dev_ull_ptr_buffer);
-/*
-    SAFE_DELETE(int_buffer);
-    SAFE_DELETE(int_ptr_buffer);
-    SAFE_DELETE(dbl_buffer);
-    SAFE_DELETE(dbl_ptr_buffer);
-    SAFE_DELETE(int2_ptr_buffer);
-    SAFE_DELETE(char_ptr_buffer);
-*/
+   cudaFree(dev_grad_ptr_buffer);
 
 }
 

--- a/src/cuda/gpu_get2e_grad_ffff.cu
+++ b/src/cuda/gpu_get2e_grad_ffff.cu
@@ -622,7 +622,8 @@ cudaMemcpyHostToDevice);
 sizeof(int)*ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(QUICKDouble)*ERI_GRAD_FFFF_SMEM_DBL_SIZE*ERI_GRAD_FFFF_TPB+sizeof(QUICKDouble*)*ERI_GRAD_FFFF_SMEM_DBL_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(int*)*ERI_GRAD_FFFF_SMEM_INT_PTR_SIZE*ERI_GRAD_FFFF_TPB+
             sizeof(int2*)*ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned
-char*)*ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned char)*ERI_GRAD_FFFF_SMEM_CHAR_SIZE>>>(dev_int_buffer,
+char*)*ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB+sizeof(unsigned char)*ERI_GRAD_FFFF_SMEM_CHAR_SIZE+
+ sizeof(QUICKULL*)*ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB>>>(dev_int_buffer,
 dev_int_ptr_buffer, dev_dbl_buffer, dev_dbl_ptr_buffer, dev_int2_ptr_buffer, dev_char_ptr_buffer, dev_char_buffer,
 dev_ull_ptr_buffer,gpu->gpu_sim.ffStart, gpu->gpu_sim.sqrQshell)))
 

--- a/src/cuda/gpu_get2e_grad_ffff.cuh
+++ b/src/cuda/gpu_get2e_grad_ffff.cuh
@@ -620,7 +620,7 @@ __device__ __forceinline__ void hrrwholegrad2_ffff(QUICKDouble* const Yaax, QUIC
                                              const QUICKDouble RBx, const QUICKDouble RBy, const QUICKDouble RBz, \
                                              const QUICKDouble RCx, const QUICKDouble RCy, const QUICKDouble RCz, \
                                              const QUICKDouble RDx, const QUICKDouble RDy, const QUICKDouble RDz, int* const smem_int, 
-int** const smem_int_ptr, QUICKDouble** const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char, bool bprint)
+int** const smem_int_ptr, QUICKDouble** const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char)
 {
     unsigned char angularL[12], angularR[12];
     QUICKDouble coefAngularL[12], coefAngularR[12];
@@ -651,14 +651,6 @@ int** const smem_int_ptr, QUICKDouble** const smem_dbl_ptr, unsigned char** cons
                           LOC2(DEV_SIM_CHAR_PTR_KLMN,0,JJJ-1,3,DEV_SIM_INT_NBASIS), LOC2(DEV_SIM_CHAR_PTR_KLMN,1,JJJ-1,3,DEV_SIM_INT_NBASIS), LOC2(DEV_SIM_CHAR_PTR_KLMN,2,JJJ-1,3,DEV_SIM_INT_NBASIS), \
                           J, coefAngularL, angularL, smem_char);
 
-if(bprint){
-    for (int i = 4; i< 84; i++) {
-        for (int j = 10; j< 120; j++) {
-printf("Test Yax1: %d %d %d %d %.9f \n", j-STORE_INIT_J_AA, i-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA, LOCSTORE(storeAA,
-j-STORE_INIT_J_AA, i-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
-        }
-    }
-}
 
     for (int i = 0; i<numAngularL; i++) {
         for (int j = 0; j<numAngularR; j++) {
@@ -666,14 +658,10 @@ j-STORE_INIT_J_AA, i-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
                 *Yaax = *Yaax + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeAA, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
 
-if(bprint) printf("Yax1: %d %d %d %d %.9f \n", angularL[i]-1-STORE_INIT_I_AA, angularR[j]-1-STORE_INIT_J_AA, STORE_DIM_I_AA, STORE_DIM_J_AA, LOCSTORE(storeAA,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
-
 //            }
         }
     }
    
-//if(bprint) printf("Yaax: %.9f \n", *Yaax );
  
     numAngularL = lefthrr(RAx, RAy, RAz, RBx, RBy, RBz, \
                           LOC2(DEV_SIM_CHAR_PTR_KLMN,0,III-1,3,DEV_SIM_INT_NBASIS), LOC2(DEV_SIM_CHAR_PTR_KLMN,1,III-1,3,DEV_SIM_INT_NBASIS) + 1, LOC2(DEV_SIM_CHAR_PTR_KLMN,2,III-1,3,DEV_SIM_INT_NBASIS), \
@@ -684,8 +672,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Yaay = *Yaay + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeAA, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
-if(bprint) printf("Yax2: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeAA,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
 //            }
         }
     }
@@ -699,8 +685,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Yaaz = *Yaaz + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeAA, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
-if(bprint) printf("Yax3: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeAA,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
 //            }
         }
     }
@@ -714,8 +698,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Ybbx = *Ybbx + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeBB, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
-if(bprint) printf("Ybx1: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeBB,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
 //            }
         }
     }
@@ -729,8 +711,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Ybby = *Ybby + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeBB, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
-if(bprint) printf("Ybx2: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeBB,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
 //            }
         }
     }
@@ -744,8 +724,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Ybbz = *Ybbz + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeBB, angularL[i]-1-STORE_INIT_J_AA,
 angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA);
-if(bprint) printf("Ybx3: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeBB,
-angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, STORE_DIM_I_AA) );
 //            }
         }
     }
@@ -765,8 +743,6 @@ angularL[i]-1-STORE_INIT_J_AA, angularR[j]-1-STORE_INIT_I_AA, STORE_DIM_J_AA, ST
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yaax = *Yaax - LOC2(DEV_SIM_CHAR_PTR_KLMN,0,III-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -785,8 +761,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yaay = *Yaay - LOC2(DEV_SIM_CHAR_PTR_KLMN,1,III-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -804,8 +778,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yaaz = *Yaaz - LOC2(DEV_SIM_CHAR_PTR_KLMN,2,III-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -826,8 +798,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Ybbx = *Ybbx - LOC2(DEV_SIM_CHAR_PTR_KLMN,0,JJJ-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -847,8 +817,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Ybby = *Ybby - LOC2(DEV_SIM_CHAR_PTR_KLMN,1,JJJ-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -867,8 +835,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Ybbz = *Ybbz - LOC2(DEV_SIM_CHAR_PTR_KLMN,2,JJJ-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
                     
 //                }
             }
@@ -899,8 +865,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Yccx = *Yccx + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeCC, angularL[i]-1-STORE_INIT_J_CC,
 angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeCC,
-angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC) );
 //            }
         }
     }
@@ -917,8 +881,6 @@ angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, ST
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yccx = *Yccx - LOC2(DEV_SIM_CHAR_PTR_KLMN,0,KKK-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -939,8 +901,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Yccy = *Yccy + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeCC, angularL[i]-1-STORE_INIT_J_CC,
 angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeCC,
-angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC) );
 //            }
         }
     }
@@ -958,8 +918,6 @@ angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, ST
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yccy = *Yccy - LOC2(DEV_SIM_CHAR_PTR_KLMN,1,KKK-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -979,8 +937,6 @@ angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //            if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                 *Yccz = *Yccz + coefAngularL[i] * coefAngularR[j] * LOCSTORE(storeCC, angularL[i]-1-STORE_INIT_J_CC,
 angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(storeCC,
-angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, STORE_DIM_I_CC) );
 //            }
         }
     }
@@ -998,8 +954,6 @@ angularL[i]-1-STORE_INIT_J_CC, angularR[j]-1-STORE_INIT_I_CC, STORE_DIM_J_CC, ST
 //                if (angularL[i] <= STOREDIM && angularR[j] <= STOREDIM) {
                     *Yccz = *Yccz - LOC2(DEV_SIM_CHAR_PTR_KLMN,2,KKK-1,3,DEV_SIM_INT_NBASIS) * coefAngularL[i] * coefAngularR[j] *
 LOCSTORE(store, angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM);
-if(bprint) printf("Y: %d %d %d %d %.9f \n", angularL[i]-1, angularR[j]-1, STOREDIM, STOREDIM, LOCSTORE(store,
-angularL[i]-1-STORE_INIT, angularR[j]-1-STORE_INIT, STORE_DIM, STORE_DIM) );
 //                }
             }
         }
@@ -1046,7 +1000,7 @@ __device__ __inline__ void iclass_grad_ffff
 unsigned int LL, const QUICKDouble DNMax, \
 QUICKDouble* const YVerticalTemp, QUICKDouble* const store, QUICKDouble* const store2, QUICKDouble* const storeAA, QUICKDouble*
 const storeBB, QUICKDouble* const storeCC, int* const smem_int, QUICKDouble* const smem_dbl, int** const smem_int_ptr, QUICKDouble**
-const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char, QUICKAtomicType** const smem_ull_ptr){
+const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char, QUICKAtomicType** const smem_grad_ptr){
     /*
      kAtom A, B, C ,D is the coresponding atom for shell ii, jj, kk, ll
      and be careful with the index difference between Fortran and C++,
@@ -1515,26 +1469,8 @@ const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const sm
                                     QUICKDouble Ybbx, Ybby, Ybbz;
                                     QUICKDouble Yccx, Yccy, Yccz;
 
-bool bprint=false;
-//if(II == 9 && JJ == 19 && KK == 29 && LL == 39 && III == 26 && JJJ == 61 && KKK == 96 && LLL == 139) bprint=true;
-//if( I == 3 && J == 3 && K == 3 && L == 3) bprint=true;
 
 
-if(bprint){
-
-                for (int i = 4; i< 120; i++) {
-                    for (int j = 10; j< 120; j++) {
-                        if (i < STOREDIM && j < STOREDIM) {
-//                            printf("STOREAA   %d %d %d %d   %d   %d   %.9f \n",Sumindex[K], Sumindex[K+L+2],
-//Sumindex[I], Sumindex[I+J+2], j, i, LOCSTORE(storeAA, j, i , STOREDIM, STOREDIM));
-                        }
-                    }
-                } 
-
-}
-
-
-//if(bprint) printf("calling hrrwholegrad2 bprint \n");
 
                                     hrrwholegrad2_ffff
                                     (&Yaax, &Yaay, &Yaaz, \
@@ -1544,13 +1480,9 @@ if(bprint){
                                                   III, JJJ, KKK, LLL, IJKLTYPE, \
                                                   store, storeAA, storeBB, storeCC, \
                                                   RAx, RAy, RAz, RBx, RBy, RBz, \
-                                                  RCx, RCy, RCz, RDx, RDy, RDz, smem_int, smem_int_ptr, smem_dbl_ptr, smem_char_ptr, smem_char, bprint);
+                                                  RCx, RCy, RCz, RDx, RDy, RDz, smem_int, smem_int_ptr, smem_dbl_ptr, smem_char_ptr, smem_char);
 
 #if defined int_spdf3 || defined int_spdf4
-if(bprint){ 
-//if( I == 3 && J == 3 && K == 3 && L == 3){
-//printf("Y   %d   %d   %d   %d   %d   %d   %d   %d   %d   %d   %d   %d   %.9f   %.9f   %.9f   %.9f   %.9f   %.9f   %.9f   %.9f   %.9f\n",II, JJ, KK, LL, I, J, K, L, III, JJJ, KKK, LLL, Yaax, Yaay, Yaaz, Ybbx, Ybby, Ybbz, Yccx, Yccy, Yccz);
-}
 #endif                                    
                                     QUICKDouble constant = 0.0 ;
                                     
@@ -1700,44 +1632,44 @@ if(bprint){
    
 #ifdef USE_LEGACY_ATOMICS 
 
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart], AGradx);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart + 1], AGrady);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart + 2], AGradz);
+    GRADADD(DEV_SIM_PTR_GRAD[AStart], AGradx);
+    GRADADD(DEV_SIM_PTR_GRAD[AStart + 1], AGrady);
+    GRADADD(DEV_SIM_PTR_GRAD[AStart + 2], AGradz);
     
     
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart], BGradx);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart + 1], BGrady);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart + 2], BGradz);
+    GRADADD(DEV_SIM_PTR_GRAD[BStart], BGradx);
+    GRADADD(DEV_SIM_PTR_GRAD[BStart + 1], BGrady);
+    GRADADD(DEV_SIM_PTR_GRAD[BStart + 2], BGradz);
     
     
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart], CGradx);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart + 1], CGrady);
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart + 2], CGradz);
+    GRADADD(DEV_SIM_PTR_GRAD[CStart], CGradx);
+    GRADADD(DEV_SIM_PTR_GRAD[CStart + 1], CGrady);
+    GRADADD(DEV_SIM_PTR_GRAD[CStart + 2], CGradz);
     
     
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
-    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));
+    GRADADD(DEV_SIM_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
+    GRADADD(DEV_SIM_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
+    GRADADD(DEV_SIM_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));
 
 #else 
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart], AGradx);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart + 1], AGrady);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart + 2], AGradz);
+    atomicAdd(&DEV_SIM_PTR_GRAD[AStart], AGradx);
+    atomicAdd(&DEV_SIM_PTR_GRAD[AStart + 1], AGrady);
+    atomicAdd(&DEV_SIM_PTR_GRAD[AStart + 2], AGradz);
 
 
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart], BGradx);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart + 1], BGrady);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart + 2], BGradz);
+    atomicAdd(&DEV_SIM_PTR_GRAD[BStart], BGradx);
+    atomicAdd(&DEV_SIM_PTR_GRAD[BStart + 1], BGrady);
+    atomicAdd(&DEV_SIM_PTR_GRAD[BStart + 2], BGradz);
 
 
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart], CGradx);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart + 1], CGrady);
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart + 2], CGradz);
+    atomicAdd(&DEV_SIM_PTR_GRAD[CStart], CGradx);
+    atomicAdd(&DEV_SIM_PTR_GRAD[CStart + 1], CGrady);
+    atomicAdd(&DEV_SIM_PTR_GRAD[CStart + 2], CGradz);
 
 
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
-    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));   
+    atomicAdd(&DEV_SIM_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
+    atomicAdd(&DEV_SIM_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
+    atomicAdd(&DEV_SIM_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));   
 #endif
 
     return;
@@ -1755,7 +1687,7 @@ __launch_bounds__(ERI_GRAD_FFFF_TPB, ERI_GRAD_FFFF_BPSM) getGrad_oshell_kernel_f
 __global__ void 
 __launch_bounds__(ERI_GRAD_FFFF_TPB, ERI_GRAD_FFFF_BPSM) getGrad_kernel_ffff(int *dev_int_data, 
 int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_data, int2
-**dev_int2_ptr_data, unsigned char **dev_char_ptr_data, unsigned char *dev_char_data, QUICKAtomicType **dev_ull_ptr_data, const int ffStart, const int sqrQshell)
+**dev_int2_ptr_data, unsigned char **dev_char_ptr_data, unsigned char *dev_char_data, QUICKAtomicType **dev_grad_ptr_data, const int ffStart, const int sqrQshell)
 #endif
 #endif
 {
@@ -1769,7 +1701,7 @@ int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_dat
     unsigned char **smem_char_ptr = (unsigned char**) &smem_int2_ptr[ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     int *smem_int = (int*) &smem_char_ptr[ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     unsigned char *smem_char=(unsigned char*) &smem_int[ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB];
-    QUICKAtomicType **smem_ull_ptr = (QUICKAtomicType**) &smem_char[ERI_GRAD_FFFF_SMEM_CHAR_SIZE];
+    QUICKAtomicType **smem_grad_ptr = (QUICKAtomicType**) &smem_char[ERI_GRAD_FFFF_SMEM_CHAR_SIZE];
 
     for(int i = threadIdx.x; i<ERI_GRAD_FFFF_TPB*ERI_GRAD_FFFF_SMEM_DBL_SIZE ; i+=blockDim.x)
         smem_dbl[i]=dev_dbl_data[i];
@@ -1792,8 +1724,8 @@ int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_dat
     for(int i = threadIdx.x; i<ERI_GRAD_FFFF_SMEM_CHAR_SIZE ; i+=blockDim.x)
         smem_char[i]=dev_char_data[i];
 
-    for(int i = threadIdx.x; i<ERI_GRAD_FFFF_TPB*ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE ; i+=blockDim.x)
-        smem_ull_ptr[i]=dev_ull_ptr_data[i];
+    for(int i = threadIdx.x; i<ERI_GRAD_FFFF_TPB*ERI_GRAD_FFFF_SMEM_PTR_SIZE ; i+=blockDim.x)
+        smem_grad_ptr[i]=dev_grad_ptr_data[i];
 
 __syncthreads();
 
@@ -1867,7 +1799,7 @@ DNMax) > DEV_SIM_DBL_GRADCUTOFF) {
                     if( iii == 3 && jjj == 3 && kkk ==3 && lll ==3){
                     iclass_oshell_grad_ffff(iii, jjj, kkk, lll, ii, jj, kk, ll, DNMax, DEV_SIM_DBL_PTR_YVERTICALTEMP+offset,
 DEV_SIM_DBL_PTR_STORE+offset, DEV_SIM_DBL_PTR_STORE2+offset, DEV_SIM_DBL_PTR_STOREAA+offset, DEV_SIM_DBL_PTR_STOREBB+offset,
-DEV_SIM_DBL_PTR_STORECC+offset, smem_int, smem_dbl, smem_int_ptr, smem_dbl_ptr, smem_char_ptr, smem_char, smem_ull_ptr);
+DEV_SIM_DBL_PTR_STORECC+offset, smem_int, smem_dbl, smem_int_ptr, smem_dbl_ptr, smem_char_ptr, smem_char, smem_grad_ptr);
                     }
 #endif
 #else
@@ -1876,7 +1808,7 @@ DEV_SIM_DBL_PTR_STORECC+offset, smem_int, smem_dbl, smem_int_ptr, smem_dbl_ptr, 
 		    if( iii == 3 && jjj == 3 && kkk ==3 && lll ==3){
                     iclass_grad_ffff(iii, jjj, kkk, lll, ii, jj, kk, ll, DNMax, DEV_SIM_DBL_PTR_YVERTICALTEMP+offset,
 DEV_SIM_DBL_PTR_STORE+offset, DEV_SIM_DBL_PTR_STORE2+offset, DEV_SIM_DBL_PTR_STOREAA+offset, DEV_SIM_DBL_PTR_STOREBB+offset,
-DEV_SIM_DBL_PTR_STORECC+offset, smem_int, smem_dbl, smem_int_ptr, smem_dbl_ptr,smem_char_ptr, smem_char, smem_ull_ptr);
+DEV_SIM_DBL_PTR_STORECC+offset, smem_int, smem_dbl, smem_int_ptr, smem_dbl_ptr,smem_char_ptr, smem_char, smem_grad_ptr);
 		    }
 #endif
 #endif

--- a/src/cuda/gpu_get2e_grad_ffff.cuh
+++ b/src/cuda/gpu_get2e_grad_ffff.cuh
@@ -1700,24 +1700,24 @@ if(bprint){
    
 #ifdef USE_LEGACY_ATOMICS 
 
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart], AGradx);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart + 1], AGrady);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[AStart + 2], AGradz);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart], AGradx);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart + 1], AGrady);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[AStart + 2], AGradz);
     
     
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[BStart], BGradx);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[BStart + 1], BGrady);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[BStart + 2], BGradz);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart], BGradx);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart + 1], BGrady);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[BStart + 2], BGradz);
     
     
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[CStart], CGradx);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[CStart + 1], CGrady);
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[CStart + 2], CGradz);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart], CGradx);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart + 1], CGrady);
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[CStart + 2], CGradz);
     
     
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart], (-AGradx-BGradx-CGradx));
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart + 1], (-AGrady-BGrady-CGrady));
-    GRADADD(DEV_SIM_DBL_PTR_GRADULL[DStart + 2], (-AGradz-BGradz-CGradz));
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
+    GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));
 
 #else 
     atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart], AGradx);
@@ -1769,7 +1769,7 @@ int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_dat
     unsigned char **smem_char_ptr = (unsigned char**) &smem_int2_ptr[ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     int *smem_int = (int*) &smem_char_ptr[ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     unsigned char *smem_char=(unsigned char*) &smem_int[ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB];
-    QUICKULL **smem_ull_ptr = (QUICKULL**) &smem_char[ERI_GRAD_FFFF_SMEM_ULL_PTR_SIZE*ERI_GRAD_FFFF_TPB];
+    QUICKULL **smem_ull_ptr = (QUICKULL**) &smem_char[ERI_GRAD_FFFF_SMEM_CHAR_SIZE];
 
     for(int i = threadIdx.x; i<ERI_GRAD_FFFF_TPB*ERI_GRAD_FFFF_SMEM_DBL_SIZE ; i+=blockDim.x)
         smem_dbl[i]=dev_dbl_data[i];

--- a/src/cuda/gpu_get2e_grad_ffff.cuh
+++ b/src/cuda/gpu_get2e_grad_ffff.cuh
@@ -1046,7 +1046,7 @@ __device__ __inline__ void iclass_grad_ffff
 unsigned int LL, const QUICKDouble DNMax, \
 QUICKDouble* const YVerticalTemp, QUICKDouble* const store, QUICKDouble* const store2, QUICKDouble* const storeAA, QUICKDouble*
 const storeBB, QUICKDouble* const storeCC, int* const smem_int, QUICKDouble* const smem_dbl, int** const smem_int_ptr, QUICKDouble**
-const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char, QUICKULL** const smem_ull_ptr){
+const smem_dbl_ptr, unsigned char** const smem_char_ptr, unsigned char* const smem_char, QUICKAtomicType** const smem_ull_ptr){
     /*
      kAtom A, B, C ,D is the coresponding atom for shell ii, jj, kk, ll
      and be careful with the index difference between Fortran and C++,
@@ -1720,24 +1720,24 @@ if(bprint){
     GRADADD(DEV_SIM_ULL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));
 
 #else 
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart], AGradx);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart + 1], AGrady);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[AStart + 2], AGradz);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart], AGradx);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart + 1], AGrady);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[AStart + 2], AGradz);
 
 
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[BStart], BGradx);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[BStart + 1], BGrady);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[BStart + 2], BGradz);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart], BGradx);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart + 1], BGrady);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[BStart + 2], BGradz);
 
 
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[CStart], CGradx);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[CStart + 1], CGrady);
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[CStart + 2], CGradz);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart], CGradx);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart + 1], CGrady);
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[CStart + 2], CGradz);
 
 
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
-    atomicAdd(&DEV_SIM_DBL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));   
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart], (-AGradx-BGradx-CGradx));
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart + 1], (-AGrady-BGrady-CGrady));
+    atomicAdd(&DEV_SIM_ULL_PTR_GRAD[DStart + 2], (-AGradz-BGradz-CGradz));   
 #endif
 
     return;
@@ -1755,7 +1755,7 @@ __launch_bounds__(ERI_GRAD_FFFF_TPB, ERI_GRAD_FFFF_BPSM) getGrad_oshell_kernel_f
 __global__ void 
 __launch_bounds__(ERI_GRAD_FFFF_TPB, ERI_GRAD_FFFF_BPSM) getGrad_kernel_ffff(int *dev_int_data, 
 int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_data, int2
-**dev_int2_ptr_data, unsigned char **dev_char_ptr_data, unsigned char *dev_char_data, QUICKULL **dev_ull_ptr_data, const int ffStart, const int sqrQshell)
+**dev_int2_ptr_data, unsigned char **dev_char_ptr_data, unsigned char *dev_char_data, QUICKAtomicType **dev_ull_ptr_data, const int ffStart, const int sqrQshell)
 #endif
 #endif
 {
@@ -1769,7 +1769,7 @@ int **dev_int_ptr_data, QUICKDouble *dev_dbl_data, QUICKDouble **dev_dbl_ptr_dat
     unsigned char **smem_char_ptr = (unsigned char**) &smem_int2_ptr[ERI_GRAD_FFFF_SMEM_INT2_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     int *smem_int = (int*) &smem_char_ptr[ERI_GRAD_FFFF_SMEM_CHAR_PTR_SIZE*ERI_GRAD_FFFF_TPB];
     unsigned char *smem_char=(unsigned char*) &smem_int[ERI_GRAD_FFFF_SMEM_INT_SIZE*ERI_GRAD_FFFF_TPB];
-    QUICKULL **smem_ull_ptr = (QUICKULL**) &smem_char[ERI_GRAD_FFFF_SMEM_CHAR_SIZE];
+    QUICKAtomicType **smem_ull_ptr = (QUICKAtomicType**) &smem_char[ERI_GRAD_FFFF_SMEM_CHAR_SIZE];
 
     for(int i = threadIdx.x; i<ERI_GRAD_FFFF_TPB*ERI_GRAD_FFFF_SMEM_DBL_SIZE ; i+=blockDim.x)
         smem_dbl[i]=dev_dbl_data[i];


### PR DESCRIPTION
In this PR, I have made changes to CUDA F gradient kernels to support legacy atomic add. Users won't be able to run F kernels on Kepler cards though. This is because we moved device pointers and some constants from constant memory into the shared memory. This improves the performance and the implementation we have in F gradient source files ( https://github.com/merzlab/QUICK/blob/326-support-for-legacy-atomics-in-cuda-f-gradient-kernels/src/cuda/gpu_get2e_grad_ffff.cu#L259-L505, https://github.com/merzlab/QUICK/blob/326-support-for-legacy-atomics-in-cuda-f-gradient-kernels/src/cuda/gpu_get2e_grad_ffff.cuh#L1695-L1730) is my experimental implementation. We should implement some templates, clean this up, and update other OEI/ERI/LRI kernels to use shared memory. Will be very useful for performance gain on AMD cards. 
I have also reimplemented the ERI sorting algorithm: https://github.com/merzlab/QUICK/blob/326-support-for-legacy-atomics-in-cuda-f-gradient-kernels/src/cuda/gpu_get2e_grad_ffff.cu#L167-L251. The old sorting algorithm (https://github.com/merzlab/QUICK/blob/326-support-for-legacy-atomics-in-cuda-f-gradient-kernels/src/cuda/gpu.cu#L612-L1137) has a bug and fails for sort high angular momentum ERIs properly. We should move the sorting algorithm I implemented in gpu_get2e_grad_ffff.cu into gpu.cu and do the sorting before the SCF. 