### PR TITLE
Fix for issue 337

### DIFF
--- a/src/cuda/gpu.cu
+++ b/src/cuda/gpu.cu
@@ -398,7 +398,8 @@ extern "C" void gpu_upload_method_(int* quick_method, bool* is_oshell, double* h
 	gpu -> gpu_sim.hyb_coeff = *hyb_coeff;
     }
 
-    gpu -> gpu_sim.is_oshell = *is_oshell;
+    bool interpreted_is_oshell = *is_oshell != 0;
+    gpu -> gpu_sim.is_oshell = interpreted_is_oshell;
 }
 
 #ifdef CEW


### PR DESCRIPTION
The enclosed change should resolve #337. It seems that ifort represent logical true using 255 rather than 1. As a result, when we pass the "is_oshell" flag value from Fortran to C code (https://github.com/merzlab/QUICK/blob/master/src/cuda/gpu.cu#L385-L402), the value in C code was not set properly, and closed shell kernel was invoked for open shell XC calculation (https://github.com/merzlab/QUICK/blob/master/src/cuda/gpu_getxc.cu#L98-L113). Please test and merge. 