### PR TITLE
Disable support for HIP and MPI+HIP builds

### DIFF
--- a/configure
+++ b/configure
@@ -1139,6 +1139,10 @@ set_uspec_hip_arch(){
 }
 
 if [ "$hip" = 'yes' ] || [ "$hipmpi" = 'yes' ]; then
+  echo  "Error: HIP support is currently unavailable in this QUICK release. "
+  echo  "       Support will be added back in a future release. "
+  exit 1
+
   if [ -z "$ROCM_PATH" ]; then
     echo  "Error: ROCM_PATH environment variable is not set."
     echo  "Please make sure ROCm toolkit is loaded."

--- a/quick-cmake/QUICKCudaConfig.cmake
+++ b/quick-cmake/QUICKCudaConfig.cmake
@@ -225,6 +225,8 @@ if(CUDA)
 endif()
 
 if(HIP)
+    # HIP builds currently unavailable (TODO: fix post release)
+    message(FATAL_ERROR "Error: HIP support is currently unavailable in this QUICK release. Support will be added back in a future release.")
 
     set(QUICK_GPU_PLATFORM "HIP")
     set(QUICK_GPU_TARGET_NAME "hip")


### PR DESCRIPTION
Temporarily disable support for HIP and MPI+HIP builds.  This will be revisited post next Amber release when the CUDA code stabilizes and can be ported to the HIP code.

Related: #344