### PR TITLE
AWG - fix reading heavy elements

### DIFF
--- a/src/modules/quick_molspec_module.f90
+++ b/src/modules/quick_molspec_module.f90
@@ -343,7 +343,7 @@ contains
        call rdword(keywd,i,j)
        if (is_blank(keywd,1,80)) exit
 
-       do k=0,71
+       do k=0,92
           if (keywd(i:j) == symbol(k)) then
              natom=natom+1
              ! check if atom type has been shown before


### PR DESCRIPTION
Support reading as many elements as are defined in quick_constants_module. These are 92 elements. We do not have ECPs so there are not really any basis sets that we can use beyond Kr. However, at least be consistent for the future.

Closes #356 