### PR TITLE
ioutfile intent in rather than intent out

### DIFF
--- a/src/modules/quick_cew_module.f90
+++ b/src/modules/quick_cew_module.f90
@@ -1205,7 +1205,7 @@ end do
   
     implicit none
     type(quick_cew_type), intent(in) :: self
-    integer, intent(out) :: iOutfile
+    integer, intent(in) :: iOutfile
     integer, intent(out) :: ierr
 
     if(self%use_cew) then 


### PR DESCRIPTION
file unit dummy argument intent appears to be incorrect, which could result in using an uninitialized value