### PR TITLE
Fixes Segmentation error during  MOLDEN export on CPU run

### DIFF
--- a/src/modules/quick_scf_module.f90
+++ b/src/modules/quick_scf_module.f90
@@ -807,11 +807,14 @@ contains
 #endif
         if (quick_method%debug)  call debug_SCF(jscf)
      enddo
-  
-#if (defined CUDA || defined CUDA_MPIV) && !defined(HIP)
+
+
      if(master .and. write_molden) then 
          quick_molden%nscf_snapshots(quick_molden%iexport_snapshot)=jscf 
      endif
+
+#if (defined CUDA || defined CUDA_MPIV) && !defined(HIP)
+
 
      ! sign of the coefficient matrix resulting from cusolver is not consistent
      ! with rest of the code (e.g. gradients). We have to correct this.

--- a/src/modules/quick_uscf_module.f90
+++ b/src/modules/quick_uscf_module.f90
@@ -908,11 +908,13 @@ contains
 #endif
         !if (quick_method%debug)  call debug_SCF(jscf)
      enddo
-  
-#if (defined CUDA || defined CUDA_MPIV) && !defined(HIP)
+
      if(master .and. write_molden) then
          quick_molden%nscf_snapshots(quick_molden%iexport_snapshot)=jscf
      endif  
+
+#if (defined CUDA || defined CUDA_MPIV) && !defined(HIP)
+
 
      ! sign of the coefficient matrix resulting from cusolver is not consistent
      ! with rest of the code (e.g. gradients). We have to correct this.


### PR DESCRIPTION
This update resolves a segmentation fault issue that occurred when running the application on the CPU and attempting to export data to MOLDEN format. 