### PR TITLE
AWG Fix readline compatibility for older bash versions

### DIFF
--- a/tools/runtest
+++ b/tools/runtest
@@ -322,8 +322,6 @@ get_total_tests()
   if [ "$1" = 'yes' ]; then
     tot_ene_tests="${#tests[@]}"
     tests+=(`grep "^ene_" "$test_list" | awk '{print $1}'`)
-#    readarray -t -O "${#test_names[@]}" test_names <<< \
-#              "$(grep "^ene_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
     while IFS= read -r line; do
         test_names+=("$line")
     done < <(grep "^ene_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
@@ -334,8 +332,6 @@ get_total_tests()
   if [ "$2" = 'yes' ]; then
     tot_grad_tests="${#tests[@]}"
     tests+=(`grep "^grad_" "$test_list" | awk '{print $1}'`)
-#    readarray -t -O "${#test_names[@]}" test_names <<< \
-#              "$(grep "^grad_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
     while IFS= read -r line; do
         test_names+=("$line")
     done < <(grep "^grad_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
@@ -346,8 +342,6 @@ get_total_tests()
   if [ "$3" = 'yes' ]; then
     tot_opt_tests="${#tests[@]}"
     tests+=(`grep "^opt_" "$test_list" | awk '{print $1}'`)
-#    readarray -t -O "${#test_names[@]}" test_names <<< \
-#              "$(grep "^opt_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
     while IFS= read -r line; do
         test_names+=("$line")
     done < <(grep "^opt_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
@@ -358,8 +352,6 @@ get_total_tests()
   if [ "$4" = 'yes' ]; then
     tot_api_tests="${#tests[@]}"
     tests+=(`grep "^api_" "$test_list" | awk '{print $1}'`)
-#    readarray -t -O "${#test_names[@]}" test_names <<< \
-#              "$(grep "^api_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
     while IFS= read -r line; do
         test_names+=("$line")
     done < <(grep "^api_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')

--- a/tools/runtest
+++ b/tools/runtest
@@ -322,8 +322,11 @@ get_total_tests()
   if [ "$1" = 'yes' ]; then
     tot_ene_tests="${#tests[@]}"
     tests+=(`grep "^ene_" "$test_list" | awk '{print $1}'`)
-    readarray -t -O "${#test_names[@]}" test_names <<< \
-              "$(grep "^ene_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+#    readarray -t -O "${#test_names[@]}" test_names <<< \
+#              "$(grep "^ene_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+    while IFS= read -r line; do
+        test_names+=("$line")
+    done < <(grep "^ene_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
     total_tests="${#tests[@]}"
     tot_ene_tests=$(($total_tests-$tot_ene_tests))
   fi
@@ -331,8 +334,11 @@ get_total_tests()
   if [ "$2" = 'yes' ]; then
     tot_grad_tests="${#tests[@]}"
     tests+=(`grep "^grad_" "$test_list" | awk '{print $1}'`)
-    readarray -t -O "${#test_names[@]}" test_names <<< \
-              "$(grep "^grad_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+#    readarray -t -O "${#test_names[@]}" test_names <<< \
+#              "$(grep "^grad_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+    while IFS= read -r line; do
+        test_names+=("$line")
+    done < <(grep "^grad_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
     total_tests="${#tests[@]}"
     tot_grad_tests=$(($total_tests-$tot_grad_tests))
   fi
@@ -340,8 +346,11 @@ get_total_tests()
   if [ "$3" = 'yes' ]; then
     tot_opt_tests="${#tests[@]}"
     tests+=(`grep "^opt_" "$test_list" | awk '{print $1}'`)
-    readarray -t -O "${#test_names[@]}" test_names <<< \
-              "$(grep "^opt_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+#    readarray -t -O "${#test_names[@]}" test_names <<< \
+#              "$(grep "^opt_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+    while IFS= read -r line; do
+        test_names+=("$line")
+    done < <(grep "^opt_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
     total_tests="${#tests[@]}"
     tot_opt_tests=$(($total_tests-$tot_opt_tests))
   fi
@@ -349,8 +358,11 @@ get_total_tests()
   if [ "$4" = 'yes' ]; then
     tot_api_tests="${#tests[@]}"
     tests+=(`grep "^api_" "$test_list" | awk '{print $1}'`)
-    readarray -t -O "${#test_names[@]}" test_names <<< \
-              "$(grep "^api_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+#    readarray -t -O "${#test_names[@]}" test_names <<< \
+#              "$(grep "^api_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')"
+    while IFS= read -r line; do
+        test_names+=("$line")
+    done < <(grep "^api_" "$test_list" | awk 'BEGIN { FPAT="([^#]+)"; OFS="\n"; } {print $2}')
     total_tests="${#tests[@]}"
     tot_api_tests=$(($total_tests-$tot_api_tests))
   fi


### PR DESCRIPTION
Older bash versions do not support readline.
This includes bash shipping with MacOS (due to licensing).
This PR replaces readline with while loop in runtest script.
(code generated by ChatGPT and tested on MacOS 15.2 with bash 3.2.57 and Almalinx 9.3 with bash 5.1.8)