### PR TITLE
AWG: Remove duplicate definition of DLFIND_MODULES_SOURCES

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,23 +71,6 @@ set(DLFIND_MODULES_SOURCES
         dlf_stat_module.f90 dlf_svnversion.f90 
         dlf_task.f90 dlf_time.f90 dlf_util.f90)
 
-set(DLFIND_MODULES_SOURCES
-        dlf_allocate.f90 dlf_checkpoint.f90 
-        dlf_conint.f90 dlf_convergence.f90 
-        dlf_coords.f90 dlf_dimer.f90
-        dlf_formstep.f90 dlf_global_module.f90 
-        dlf_hdlc_constraint.f90 dlf_hdlc_hdlclib.f90 
-        dlf_hdlc_interface.f90 dlf_hdlc_matrixlib.f90 
-        dlf_hdlc_primitive.f90 dl_find.f90 
-        dlfind_main_driver.f90
-        dlf_lbfgs.f90 dlf_linalg.f90 
-        dlf_microiter.f90
-        dlf_neb.f90 dlf_parallel_opt.f90 
-        dlf_qts.f90 dlf_scalestep.f90
-        dlf_serial.f90 dlf_sort.f90 
-        dlf_stat_module.f90 dlf_svnversion.f90 
-        dlf_task.f90 dlf_time.f90 dlf_util.f90)
-
 set(DFTD3_SOURCES
 	api.f90  common.f90  core.f90  pars.f90  sizes.f90)
 


### PR DESCRIPTION
DLFIND_MODULES_SOURCES was defined twice.
Remove duplicate from CMakeLists.txt