### PR TITLE
Fixes from AmberTools 2025 Integration Part 2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,7 +130,7 @@ add_library(libquick SHARED ${QUICK_MODULES_SOURCES_FULLPATH} ${DFTD3_SOURCES_FU
 	${QUICK_SUBS_FORTRAN_SOURCES_FULLPATH} ${QUICK_SUBS_CXX_SOURCES_FULLPATH}
 	${DLFIND_MODULES_SOURCES_FULLPATH} ${QUICK_GENERAL_SOURCES})
 target_compile_options(libquick PRIVATE
-	"$<$<COMPILE_LANGUAGE:FORTRAN>:${OPT_FFLAGS}>"
+	"$<$<COMPILE_LANGUAGE:Fortran>:${OPT_FFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:C>:${OPT_CFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:CXX>:${OPT_CXXFLAGS}>")
 config_module_dirs(libquick quick/serial libxc/serial)
@@ -302,7 +302,7 @@ endif()
 
 add_executable(quick ${MAIN_SOURCES})
 target_compile_options(quick PRIVATE 
-	"$<$<COMPILE_LANGUAGE:FORTRAN>:${OPT_FFLAGS}>"
+	"$<$<COMPILE_LANGUAGE:Fortran>:${OPT_FFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:C>:${OPT_CFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:CXX>:${OPT_CXXFLAGS}>")
 config_module_dirs(quick quick/serial libxc/serial)
@@ -310,7 +310,7 @@ target_link_libraries(quick libquick)
 
 add_executable(test-api ${TEST_API_SOURCES})
 target_compile_options(test-api PRIVATE
-	"$<$<COMPILE_LANGUAGE:FORTRAN>:${OPT_FFLAGS}>"
+	"$<$<COMPILE_LANGUAGE:Fortran>:${OPT_FFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:C>:${OPT_CFLAGS}>"
 	"$<$<COMPILE_LANGUAGE:CXX>:${OPT_CXXFLAGS}>")
 config_module_dirs(test-api quick/serial libxc/serial)


### PR DESCRIPTION
This PR fixes setting the Fortran source compiler optimization flags in CMake builds (due to an issue with case-senstive naming with COMPILE_LANAUGE in generator expressions [FORTRAN -> Fortran]).

Credit to @vtripath65 for noticing performance regressions in Fortran sources which led to this fix.