### PR TITLE
Fixes from AmberTools 2025 Integration Part 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,41 @@ if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 
+# Clang
+# --------------------------------------------------------------------
+if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")
+    list(APPEND OPT_CFLAGS "-O2" "-mtune=native")
+
+    if (WARNINGS)
+	add_flags(C -Wall -Wno-unused-function)
+
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(C -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(C -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+endif()
+
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    list(APPEND OPT_CXXFLAGS "-O2" "-mtune=native")
+
+    if (WARNINGS)
+	add_flags(CXX -Wall -Wno-unused-function)
+
+	if(NOT UNUSED_WARNINGS)
+	    add_flags(CXX -Wno-unused-variable -Wno-unused-but-set-variable)
+	endif()
+
+	if(NOT UNINITIALIZED_WARNINGS)
+	    add_flags(CXX -Wno-uninitialized -Wno-maybe-uninitialized)
+	endif()
+    endif()
+endif()
+
+
 # Intel
 # --------------------------------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ list(APPEND NO_OPT_CXXFLAGS "-O0")
 # GNU
 # --------------------------------------------------------------------
 if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND TARGET_ARCH STREQUAL "arm64")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
 	    execute_process(COMMAND sysctl machdep.cpu.brand_string OUTPUT_VARIABLE CPU_INFO)
 
 	    string(REGEX MATCH "(M[0-9]*)" _ "${CPU_INFO}")
@@ -100,7 +100,7 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND TARGET_ARCH STREQUAL "arm64")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
 	    if("${CPU_VERSION}" STREQUAL "M1" OR "${CPU_VERSION}" STREQUAL "M2")
 		    list(APPEND OPT_CXXFLAGS "-O2" "-mtune=native")
 	    else()
@@ -132,7 +132,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif()
 
 if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND TARGET_ARCH STREQUAL "arm64")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64")
 	    if("${CPU_VERSION}" STREQUAL "M1" OR "${CPU_VERSION}" STREQUAL "M2")
 		    list(APPEND OPT_FFLAGS "-O2" "-mtune=native")
 	    else()


### PR DESCRIPTION
This PR addresses several issues:
- CMake compiler flags not correctly set for mixed Clang/GCC builds (`-DCOMPILER=CLANG`)
- Fix improper GCC compiler flags being set for recent Apple ARM CPUs (>= M3) for CMake builds due to limitations in upstream Amber/AmberTools CMake target architecture detection