### PR TITLE
AWG: Bugfix: Add missing comma in write statement field descriptor

### DIFF
--- a/src/dlfind/dlf_convergence.f90
+++ b/src/dlfind/dlf_convergence.f90
@@ -118,9 +118,9 @@ subroutine convergence_test(icycle,tene,tconv)
     le=(svar < tole)
     if(printl>0) then
       if(le) then
-        write(stdout,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5" )")')svar,tole
+        write(stdout,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5," )")')svar,tole
       else
-        write(stdout,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5" )")')svar,tole 
+        write(stdout,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5," )")')svar,tole 
       end if
     end if
 
@@ -128,9 +128,9 @@ subroutine convergence_test(icycle,tene,tconv)
     ls=(vals < tols)
     if(printl>0) then
       if(ls) then
-        write(stdout,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5" )")')vals,tols
+        write(stdout,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5," )")')vals,tols
       else
-        write(stdout,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5" )")')vals,tols
+        write(stdout,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5," )")')vals,tols
       end if
     end if
     
@@ -138,9 +138,9 @@ subroutine convergence_test(icycle,tene,tconv)
     lrmss=(valrmss < tolrmss)
     if(printl>0) then
       if(lrmss) then
-        write(stdout,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5" )")')valrmss,tolrmss
+        write(stdout,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5," )")')valrmss,tolrmss
       else
-        write(stdout,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5" )")')valrmss,tolrmss
+        write(stdout,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5," )")')valrmss,tolrmss
       end if
     end if
     
@@ -158,9 +158,9 @@ subroutine convergence_test(icycle,tene,tconv)
   lg=(valg < tolg)
   if(printl>0) then
     if(lg) then
-      write(stdout,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5" )")')valg,tolg
+      write(stdout,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5," )")')valg,tolg
     else
-      write(stdout,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5" )")')valg,tolg
+      write(stdout,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5," )")')valg,tolg
     end if
   end if
 
@@ -168,9 +168,9 @@ subroutine convergence_test(icycle,tene,tconv)
   lrmsg=(valrmsg < tolrmsg)
   if(printl>0) then
     if(lrmsg) then
-      write(stdout,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5" )")') valrmsg,tolrmsg
+      write(stdout,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5," )")') valrmsg,tolrmsg
     else
-      write(stdout,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5" )")') valrmsg,tolrmsg
+      write(stdout,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5," )")') valrmsg,tolrmsg
     end if
   end if
 

--- a/src/modules/quick_method_module.f90
+++ b/src/modules/quick_method_module.f90
@@ -486,12 +486,12 @@ module quick_method_module
             ! computing esp, efield and efg
             if (self%esp_charge)then
               write(io,'(" ESP CHARGE CALCULATION")')
-              write(io,'(" ESP grids are created at " F5.3 " A spacing ")') self%espgrid_spacing
+              write(io,'(" ESP grids are created at ", F5.3, " A spacing ")') self%espgrid_spacing
               if (self%vdw_radii == "BONDI")then
-                write(io,'(" Van der waals radii for ESP charges are obtained from " A)') &
+                write(io,'(" Van der waals radii for ESP charges are obtained from ", A)') &
                   "J. Phys. Chem. 1964, 68, 3, 441–451"
               else if (self%vdw_radii == "TC")then
-                write(io,'(" Van der waals radii for ESP charges are obtained from " A)') &
+                write(io,'(" Van der waals radii for ESP charges are obtained from ", A)') &
                   "J. Chem. Theory Comput. 2024, 20, 17, 7469–7478"
               else
                 call PrtErr(OUTFILEHANDLE, 'The keyword vdw_radii has unknown value. Please use either BONDI or TC.')

--- a/src/modules/quick_optimizer_module.f90
+++ b/src/modules/quick_optimizer_module.f90
@@ -297,12 +297,12 @@ contains
 
            if (i.gt.1) then
               Write (ioutfile,'(" OPTIMIZATION STATISTICS:")')
-              Write (ioutfile,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5" )")') quick_qm_struct%Etot-Elast, &
+              Write (ioutfile,'(" ENERGY CHANGE           = ",E20.10," (REQUEST= ",E12.5," )")') quick_qm_struct%Etot-Elast, &
                                                                                           quick_method%EChange
-              Write (ioutfile,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5" )")') geomax,quick_method%geoMaxCrt
-              Write (ioutfile,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5" )")') georms,quick_method%gRMSCrt
-              !Write (ioutfile,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5" )")') gradmax,quick_method%gradMaxCrt
-              Write (ioutfile,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5" )")') gradnorm,quick_method%gNormCrt
+              Write (ioutfile,'(" MAXIMUM GEOMETRY CHANGE = ",E20.10," (REQUEST= ",E12.5," )")') geomax,quick_method%geoMaxCrt
+              Write (ioutfile,'(" GEOMETRY CHANGE RMS     = ",E20.10," (REQUEST= ",E12.5," )")') georms,quick_method%gRMSCrt
+              !Write (ioutfile,'(" MAXIMUM GRADIENT ELEMENT= ",E20.10," (REQUEST= ",E12.5," )")') gradmax,quick_method%gradMaxCrt
+              Write (ioutfile,'(" GRADIENT NORM           = ",E20.10," (REQUEST= ",E12.5," )")') gradnorm,quick_method%gNormCrt
 
               EChg = quick_qm_struct%Etot-Elast
               done = quick_method%geoMaxCrt.gt.geomax
@@ -312,7 +312,7 @@ contains
               !done = done.and.quick_method%gNormCrt.gt.gradnorm
            else
               Write (ioutfile,'(" OPTIMZATION STATISTICS:")')
-              Write (ioutfile,'(" MAXIMUM GRADIENT ELEMENT = ",E20.10," (REQUEST = ",E20.10" )")') gradmax,quick_method%gradMaxCrt
+              Write (ioutfile,'(" MAXIMUM GRADIENT ELEMENT = ",E20.10," (REQUEST = ",E20.10," )")') gradmax,quick_method%gradMaxCrt
               done = quick_method%gradMaxCrt.gt.gradmax
               done = done.and.quick_method%gNormCrt.gt.gradnorm
               if (done) then


### PR DESCRIPTION
Required comma as field separator was missing in some format descriptors for write statements in geometry optimization routines (legacy optimizer, DLFIND, methods module).

This was silently accepted with GCC versions <= 14 but leads to runtime errors with GCC 15.

Fixes errors with GCC 15, which is more strict.