### PR TITLE
 MVP CI/CD Implementation for QUICK CUDA (with f functions) Build and Test Workflow

### DIFF
--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -11,11 +11,13 @@ on:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_mpi.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_mpi.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
 
 jobs:
   build-and-test-cuda:

--- a/.github/workflows/build_test_cuda_enablef.yml
+++ b/.github/workflows/build_test_cuda_enablef.yml
@@ -1,0 +1,110 @@
+name: 'Build and Test QUICK CUDA Version (F Functions Enabled)'
+
+defaults:
+  run:
+    shell: bash
+
+on: workflow_dispatch
+
+jobs:
+  build-and-test-cuda:
+    timeout-minutes: 2880 # set timeout to 48 hours
+    # The specific label for the self-hosted GPU runner
+    runs-on: [self-hosted, linux-gpu-cuda]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # Only one configuration based on versions provided inside of runner
+          - os: 'ubuntu-22.04'
+            compiler-type: 'GNU'
+            compiler-version: '11'
+            cuda-version: '12.4'
+            c-compiler: 'gcc'
+            cxx-compiler: 'g++'
+            fortran-compiler: 'gfortran'
+
+    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - ${{ matrix.compiler-type }}
+
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+
+      - name: 'Setup Environment Variables for Building and Running Tests'
+        run: |
+          echo "QUICK_BASIS=$PWD/install/basis" >> "$GITHUB_ENV"
+          echo "CUDA_PATH=/usr/local/cuda-${{ matrix.cuda-version }}" >> "$GITHUB_ENV"
+          # Add CUDA binaries and libs to paths
+          echo "PATH=$PWD/install/bin:/usr/local/cuda-${{ matrix.cuda-version }}/bin:$PATH" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$PWD/install/lib:/usr/local/cuda-${{ matrix.cuda-version }}/lib64:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$PWD/install/lib:/usr/local/cuda-${{ matrix.cuda-version }}/lib64:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "CC=${{ matrix.c-compiler }}" >> "$GITHUB_ENV"
+          echo "CXX=${{ matrix.cxx-compiler }}" >> "$GITHUB_ENV"
+          echo "FC=${{ matrix.fortran-compiler }}" >> "$GITHUB_ENV"
+
+      - name: 'Log Software Environment Configuration'
+        run: |
+          echo "OS version:"
+          cat /etc/os-release
+          echo
+          echo "Kernel version:"
+          uname -a
+          echo
+          echo "Glibc version:"
+          ldd --version
+          echo
+          echo "Fortran compiler version:"
+          ${{ matrix.fortran-compiler }} --version
+          echo
+          echo "CMake version:"
+          cmake --version
+          echo
+          echo "GPU Information:"
+          nvidia-smi
+          echo "CUDA Compiler version:"
+          nvcc --version
+
+      # cleans up in case previous builds/installs persist
+      - name: 'Cleanup Previous Builds'
+        run: |
+          rm -rf build/
+          rm -rf install/
+
+      - name: 'Configure CUDA Version'
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCOMPILER=${{ matrix.compiler-type }} \
+            -DCUDA=TRUE -DQUICK_USER_ARCH=ampere -DCMAKE_INSTALL_PREFIX=$PWD/../install -DENABLEF=TRUE
+
+      - name: 'Build and Install'
+        run: |
+          cd build
+          cmake --build . --parallel 3 --verbose
+          cmake --install .
+
+      - name: 'Run Tests'
+        run: |
+          cd install
+          ./runtest --cuda --full
+
+      - name: 'Upload Test Artifacts for CUDA Version'
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+          path: |
+            ${{ github.workspace }}/install/runtest.log
+            ${{ github.workspace }}/install/runtest-verbose.log
+            ${{ github.workspace }}/install/test/runs/cuda
+          retention-days: 3
+          compression-level: 6
+
+      - name: 'Download Test Artifacts for CUDA Version'
+        uses: actions/download-artifact@v4
+        with:
+          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+
+      - name: 'Display Artifacts'
+        run: |
+          ls -R 

--- a/.github/workflows/build_test_mpi.yml
+++ b/.github/workflows/build_test_mpi.yml
@@ -10,11 +10,13 @@ on:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_cuda.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_cuda.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
 
 jobs:
   build-and-test-mpi-legacy-configure-make:

--- a/.github/workflows/build_test_serial.yml
+++ b/.github/workflows/build_test_serial.yml
@@ -10,11 +10,13 @@ on:
       - '**.md'
       - '.github/workflows/build_test_mpi.yml'
       - '.github/workflows/build_test_cuda.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_mpi.yml'
       - '.github/workflows/build_test_cuda.yml'
+      - '.github/workflows/build_test_cuda_enablef.yml'
 
 jobs:
   build-and-test-serial-legacy-configure-make:


### PR DESCRIPTION
This workflow is for QUICK build and test CUDA version with f functions enabled.

This version can take a long time and thus may (at times) timeout/disconnect (ie. because of how long it takes, it can accidentally disonnect from server node). The time for build can vary / be unpredictable. The maximum timeout duration has been set to 48 hours to best ensure that the job can run to completion, however this does not guarantee it won't lose connection. The default build and test workflow should still be without f functions enabled, which should run automatically (#476 ) with this (enablef) workflow being ran only if needed.

Because of the memory demands of this workflow, the runner requests 48GB of memory. Since the workflow without f functions could pass with just 8GB of memory it may be optimal to have separate runners but for now we just have one runner  requesting 48GB of memory.

The workflow can only be triggered manually through the run workflow button.