### PR TITLE
Bump NVHPC SDK version in Github CI tests

### DIFF
--- a/.github/workflows/build_test_mpi.yml
+++ b/.github/workflows/build_test_mpi.yml
@@ -337,11 +337,11 @@ jobs:
           - os: 'ubuntu-24.04'
             compiler-type: 'PGI'
             mpi-type: 'OpenMPI'
-            compiler-version: '25.1'
+            compiler-version: '26.3'
             c-compiler: 'pgcc'
             cxx-compiler: 'pgcc++'
             fortran-compiler: 'pgf90'
-            compiler-install: 'nvhpc-25-1 gfortran'
+            compiler-install: 'nvhpc-26-3 gfortran'
             mpi-install: ''
             hdf5-install: ''
             hdf5-restart-support: FALSE

--- a/.github/workflows/build_test_serial.yml
+++ b/.github/workflows/build_test_serial.yml
@@ -270,11 +270,11 @@ jobs:
             hdf5-restart-support: FALSE
           - os: 'ubuntu-24.04'
             compiler-type: 'PGI'
-            compiler-version: '25.1'
+            compiler-version: '26.3'
             c-compiler: 'pgcc'
             cxx-compiler: 'pgcc++'
             fortran-compiler: 'pgf90'
-            compiler-install: 'nvhpc-25-1 gfortran'
+            compiler-install: 'nvhpc-26-3 gfortran'
             hdf5-install: ''
             hdf5-restart-support: FALSE
           - os: 'ubuntu-24.04-arm'


### PR DESCRIPTION
This PR updates the NVIDIA HPC SDK version installed and used for Github CI tests (v25.1 => v26.3).