### PR TITLE
GitHub CI remove on push, add dispatch, concurrency

### DIFF
--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/build_test_cuda_enablef.yml'
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: pr-${{ github.event.pull_request.number }}-cuda
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -6,18 +6,17 @@ defaults:
 
 on: 
   workflow_dispatch:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/build_test_serial.yml'
-      - '.github/workflows/build_test_mpi.yml'
-      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_mpi.yml'
       - '.github/workflows/build_test_cuda_enablef.yml'
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test-cuda:

--- a/.github/workflows/build_test_mpi.yml
+++ b/.github/workflows/build_test_mpi.yml
@@ -5,18 +5,17 @@ defaults:
     shell: bash
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/build_test_serial.yml'
-      - '.github/workflows/build_test_cuda.yml'
-      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_serial.yml'
       - '.github/workflows/build_test_cuda.yml'
       - '.github/workflows/build_test_cuda_enablef.yml'
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test-mpi-legacy-configure-make:

--- a/.github/workflows/build_test_mpi.yml
+++ b/.github/workflows/build_test_mpi.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/build_test_cuda_enablef.yml'
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: pr-${{ github.event.pull_request.number }}-mpi
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_test_mpi.yml
+++ b/.github/workflows/build_test_mpi.yml
@@ -5,6 +5,7 @@ defaults:
     shell: bash
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:

--- a/.github/workflows/build_test_serial.yml
+++ b/.github/workflows/build_test_serial.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/build_test_cuda_enablef.yml'
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number }}
+  group: pr-${{ github.event.pull_request.number }}-serial
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build_test_serial.yml
+++ b/.github/workflows/build_test_serial.yml
@@ -5,18 +5,17 @@ defaults:
     shell: bash
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
-      - '.github/workflows/build_test_mpi.yml'
-      - '.github/workflows/build_test_cuda.yml'
-      - '.github/workflows/build_test_cuda_enablef.yml'
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
       - '.github/workflows/build_test_mpi.yml'
       - '.github/workflows/build_test_cuda.yml'
       - '.github/workflows/build_test_cuda_enablef.yml'
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test-serial-legacy-configure-make:

--- a/.github/workflows/build_test_serial.yml
+++ b/.github/workflows/build_test_serial.yml
@@ -5,6 +5,7 @@ defaults:
     shell: bash
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:


### PR DESCRIPTION
GitHub CI should not execute on push. Instead, trigger manually if needed.
Execute automatically only for PRs.
On new push, cancel running tests, keep only tests for latest commit running.