### PR TITLE
Added compatibility for alternative gpu architectures for build-test cuda

### DIFF
--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -84,15 +84,15 @@ jobs:
 
           case "$GPU_NAME" in
             # Ampere Architecture
-            *"A2"*|*"A10"*|*"A40"*|*"A100"*|*"RTX-3090"*|*"RTX-A4000"*|*"RTX-A5000"*|*"RTX-A6000"*)
+            *"A2"*|*"A10"*|*"A40"*|*"A100"*|*"3090"*|*"A4000"*|*"A5000"*|*"A6000"*)
               QUICK_ARCH="ampere"
             ;;
             # Turing Architecture
-            *"T4"*|*"RTX-2080"*|*"RTX-8000"*|*"TITAN-RTX"*|*"Quadro-RTX-6000"*)
+            *"T4"*|*"2080"*|*"8000"*|*"TITAN-RTX"*|*"6000"*)
               QUICK_ARCH="turing"
             ;;
             # Ada lovelace Architecture
-            *L4*|*L40*|*4090*|*Ada-Generation*)
+            *L4*|*L40*|*4090*|*Ada*)
               QUICK_ARCH="adalovelace"
             ;;
             *V100*)

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -20,7 +20,7 @@ on:
       - '.github/workflows/build_test_cuda_enablef.yml'
 
 jobs:
-  build-and-test-cuda:
+  build-and-test-cuda-cmake:
     # The specific label for the self-hosted GPU runner
     runs-on: [self-hosted, linux-gpu-cuda]
     strategy:
@@ -36,7 +36,7 @@ jobs:
             cxx-compiler: 'g++'
             fortran-compiler: 'gfortran'
 
-    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - ${{ matrix.compiler-type }}
+    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - CMake - ${{ matrix.compiler-type } - ${{ matrix.compiler-version }}}
 
     steps:
       - name: 'Checkout Repository'
@@ -78,6 +78,7 @@ jobs:
 
       - name: 'Detect GPU Architecture'
         run: |
+          
           # Get the first GPU name from nvidia-smi
           GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
           echo "Detected GPU: $GPU_NAME"
@@ -85,27 +86,27 @@ jobs:
           case "$GPU_NAME" in
             # Ampere Architecture
             *"A2"*|*"A10"*|*"A40"*|*"A100"*|*"3090"*|*"A4000"*|*"A5000"*|*"A6000"*)
-              QUICK_ARCH="ampere"
+              GPU_ARCH="ampere"
             ;;
             # Turing Architecture
             *"T4"*|*"2080"*|*"8000"*|*"TITAN-RTX"*|*"6000"*)
-              QUICK_ARCH="turing"
+              GPU_ARCH="turing"
             ;;
             # Ada lovelace Architecture
             *L4*|*L40*|*4090*|*Ada*)
-              QUICK_ARCH="adalovelace"
+              GPU_ARCH="adalovelace"
             ;;
             *V100*)
-              QUICK_ARCH="volta"
+              GPU_ARCH="volta"
             ;;
             *)
               echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
-              QUICK_ARCH="ampere"
+              GPU_ARCH="ampere"
             ;;
           esac
           
-          echo "Setting QUICK_USER_ARCH to: $QUICK_ARCH"
-          echo "QUICK_USER_ARCH=$QUICK_ARCH" >> "$GITHUB_ENV"
+          echo "Setting QUICK_USER_ARCH to: $GPU_ARCH"
+          echo "QUICK_USER_ARCH=$GPU_ARCH" >> "$GITHUB_ENV"
 
       # cleans up in case previous builds/installs persist
       - name: 'Cleanup Previous Builds'
@@ -135,7 +136,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+          name: cuda-cmake-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
           path: |
             ${{ github.workspace }}/install/runtest.log
             ${{ github.workspace }}/install/runtest-verbose.log
@@ -146,7 +147,7 @@ jobs:
       - name: 'Download Test Artifacts for CUDA Version'
         uses: actions/download-artifact@v4
         with:
-          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+          name: cuda-cmake-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
 
       - name: 'Display Artifacts'
         run: |

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -76,6 +76,29 @@ jobs:
           echo "CUDA Compiler version:"
           nvcc --version
 
+      - name: 'Detect GPU Architecture'
+        run: |
+          # Get the first GPU name from nvidia-smi
+          GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
+          echo "Detected GPU: $GPU_NAME"
+
+          case "$GPU_NAME" in
+            # Ampere Architecture
+            *"A2"*|*"A10"*|*"A40"*|*"A100"*|*"RTX-3090"*|*"RTX-A4000"*|*"RTX-A5000"*|*"RTX-A6000"*)
+              QUICK_ARCH="ampere"
+            ;;
+            # Turing Architecture
+            *"T4"*|*"RTX-2080"*|*"RTX-8000"*|*"TITAN-RTX"*|*"Quadro-RTX-6000"*)
+              QUICK_ARCH="turing"
+            ;;
+            echo "Unknown GPU: $GPU_NAME. Defaulting to 'ampere'."
+            QUICK_ARCH="ampere"
+            ;;
+          esac
+          
+          echo "Setting QUICK_USER_ARCH to: $QUICK_ARCH"
+          echo "QUICK_USER_ARCH=$QUICK_ARCH" >> "$GITHUB_ENV"
+
       # cleans up in case previous builds/installs persist
       - name: 'Cleanup Previous Builds'
         run: |
@@ -87,7 +110,7 @@ jobs:
           mkdir build
           cd build
           cmake .. -DCOMPILER=${{ matrix.compiler-type }} \
-            -DCUDA=TRUE -DQUICK_USER_ARCH=ampere -DCMAKE_INSTALL_PREFIX=$PWD/../install -DENABLEF=FALSE
+            -DCUDA=TRUE -DQUICK_USER_ARCH=${{ env.QUICK_USER_ARCH }} -DCMAKE_INSTALL_PREFIX=$PWD/../install -DENABLEF=FALSE
 
       - name: 'Build and Install'
         run: |

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -91,7 +91,7 @@ jobs:
             *"T4"*|*"RTX-2080"*|*"RTX-8000"*|*"TITAN-RTX"*|*"Quadro-RTX-6000"*)
               QUICK_ARCH="turing"
             ;;
-            echo "Unknown GPU: $GPU_NAME. Defaulting to 'ampere'."
+            echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
             QUICK_ARCH="ampere"
             ;;
           esac

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -36,7 +36,7 @@ jobs:
             cxx-compiler: 'g++'
             fortran-compiler: 'gfortran'
 
-    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - CMake - ${{ matrix.compiler-type } - ${{ matrix.compiler-version }}}
+    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - CMake - ${{ matrix.compiler-type }} - ${{ matrix.compiler-version }}
 
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -91,8 +91,9 @@ jobs:
             *"T4"*|*"RTX-2080"*|*"RTX-8000"*|*"TITAN-RTX"*|*"Quadro-RTX-6000"*)
               QUICK_ARCH="turing"
             ;;
-            echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
-            QUICK_ARCH="ampere"
+            *)
+              echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
+              QUICK_ARCH="ampere"
             ;;
           esac
           

--- a/.github/workflows/build_test_cuda.yml
+++ b/.github/workflows/build_test_cuda.yml
@@ -91,6 +91,13 @@ jobs:
             *"T4"*|*"RTX-2080"*|*"RTX-8000"*|*"TITAN-RTX"*|*"Quadro-RTX-6000"*)
               QUICK_ARCH="turing"
             ;;
+            # Ada lovelace Architecture
+            *L4*|*L40*|*4090*|*Ada-Generation*)
+              QUICK_ARCH="adalovelace"
+            ;;
+            *V100*)
+              QUICK_ARCH="volta"
+            ;;
             *)
               echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
               QUICK_ARCH="ampere"

--- a/.github/workflows/build_test_cuda_enablef.yml
+++ b/.github/workflows/build_test_cuda_enablef.yml
@@ -7,7 +7,7 @@ defaults:
 on: workflow_dispatch
 
 jobs:
-  build-and-test-cuda:
+  build-and-test-cuda-enablef-cmake:
     timeout-minutes: 2880 # set timeout to 48 hours
     # The specific label for the self-hosted GPU runner
     runs-on: [self-hosted, linux-gpu-cuda]
@@ -24,7 +24,7 @@ jobs:
             cxx-compiler: 'g++'
             fortran-compiler: 'gfortran'
 
-    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - ${{ matrix.compiler-type }}
+    name: ${{ matrix.os }} - CUDA ${{ matrix.cuda-version }} - CMake - ${{ matrix.compiler-type }} - ${{ matrix.compiler-version }}
 
     steps:
       - name: 'Checkout Repository'
@@ -70,12 +70,44 @@ jobs:
           rm -rf build/
           rm -rf install/
 
+      - name: 'Detect GPU Architecture'
+        run: |
+
+          # Get the first GPU name from nvidia-smi
+          GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -n 1)
+          echo "Detected GPU: $GPU_NAME"
+
+          case "$GPU_NAME" in
+            # Ampere Architecture
+            *"A2"*|*"A10"*|*"A40"*|*"A100"*|*"3090"*|*"A4000"*|*"A5000"*|*"A6000"*)
+              GPU_ARCH="ampere"
+            ;;
+            # Turing Architecture
+            *"T4"*|*"2080"*|*"8000"*|*"TITAN-RTX"*|*"6000"*)
+              GPU_ARCH="turing"
+            ;;
+            # Ada lovelace Architecture
+            *L4*|*L40*|*4090*|*Ada*)
+              GPU_ARCH="adalovelace"
+            ;;
+            *V100*)
+              GPU_ARCH="volta"
+            ;;
+            *)
+              echo "Unknown GPU: ${GPU_NAME}. Defaulting to 'ampere'."
+              GPU_ARCH="ampere"
+            ;;
+          esac
+
+          echo "Setting QUICK_USER_ARCH to: $GPU_ARCH"
+          echo "QUICK_USER_ARCH=$GPU_ARCH" >> "$GITHUB_ENV"
+
       - name: 'Configure CUDA Version'
         run: |
           mkdir build
           cd build
           cmake .. -DCOMPILER=${{ matrix.compiler-type }} \
-            -DCUDA=TRUE -DQUICK_USER_ARCH=ampere -DCMAKE_INSTALL_PREFIX=$PWD/../install -DENABLEF=TRUE
+            -DCUDA=TRUE -DQUICK_USER_ARCH=${{ env.QUICK_USER_ARCH }} -DCMAKE_INSTALL_PREFIX=$PWD/../install -DENABLEF=TRUE
 
       - name: 'Build and Install'
         run: |
@@ -92,7 +124,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+          name: cuda-cmake-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
           path: |
             ${{ github.workspace }}/install/runtest.log
             ${{ github.workspace }}/install/runtest-verbose.log
@@ -103,7 +135,7 @@ jobs:
       - name: 'Download Test Artifacts for CUDA Version'
         uses: actions/download-artifact@v4
         with:
-          name: cuda-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
+          name: cuda-cmake-tests-${{ matrix.os }}-${{ matrix.compiler-type}}-${{ matrix.compiler-version }}-${{ matrix.cuda-version }}
 
       - name: 'Display Artifacts'
         run: |


### PR DESCRIPTION
Added compatibility for the following architectures (on top of ampere) to reduce queuing time and improve availability: volta, turing, adalovelace

Works for both enablef=TRUE and enbalef=FALSE.

Also correct name of jobs to include cmake.

List of GPUs on NRP Nautilus that can be requested:
- NVIDIA-A10
- NVIDIA-GeForce-RTX-3090
- NVIDIA-GeForce-RTX-2080-Ti
- NVIDIA-RTX-A4000
- NVIDIA-RTX-A5000
- NVIDIA-L4
- NVIDIA-L40
- NVIDIA-L40S
- Tesla-V100-SXM2-32GB
- Tesla-V100-SXM2-16GB