### PR TITLE
Refactor - Remove SCF from gradient calculation

### DIFF
--- a/src/main.f90
+++ b/src/main.f90
@@ -214,23 +214,26 @@
     timer_cumer%TIniGuess=timer_cumer%TIniGuess+timer_end%TIniGuess-timer_begin%TIniGuess &
                           -(timer_end%T2elb-timer_begin%T2elb)
 
-    if (.not.quick_method%opt .and. .not.quick_method%grad) then
+    if (.not.quick_method%opt) then
         SAFE_CALL(getEnergy(.false.,ierr))
 
         ! One electron properties (ESP, EField)
-        call compute_oeprop()
+        if (.not.quick_method%grad) then
+           call compute_oeprop()
 
-        if (master .and. quick_method%writechk) then
-            call chk_write('xyz', 3, natom, quick_molspec%xyz)
-            call chk_write('iattype', natom, quick_molspec%iattype)
+           if (master .and. quick_method%writechk) then
+              call chk_write('xyz', 3, natom, quick_molspec%xyz)
+              call chk_write('iattype', natom, quick_molspec%iattype)
 #if !defined(RESTART_HDF5)
-            call chk_write('dense', nbasis, nbasis, quick_qm_struct%dense)
-            if (quick_method%UNRST) then
-                call chk_write('denseb', nbasis, nbasis, quick_qm_struct%denseb)
-            end if
-            call chk_close()
+              call chk_write('dense', nbasis, nbasis, quick_qm_struct%dense)
+              if (quick_method%UNRST) then
+                 call chk_write('denseb', nbasis, nbasis, quick_qm_struct%denseb)
+              end if
+              call chk_close()
 #endif
-        endif
+           endif
+        end if
+                   
     endif
 
     !------------------------------------------------------------------

--- a/src/modules/include/gradient.fh
+++ b/src/modules/include/gradient.fh
@@ -111,7 +111,7 @@ contains
         enddo
      enddo
   
-     call getEnergy(.false.,ierr)
+!     call getEnergy(.false.,ierr)
   
      if (quick_method%analgrad) then
 #ifdef OSHELL

--- a/src/modules/quick_api_module.f90
+++ b/src/modules/quick_api_module.f90
@@ -560,7 +560,7 @@ subroutine run_quick(self,ierr)
                            - (timer_end%T2elb-timer_begin%T2elb)
 
   ! compute energy
-  if ( .not. quick_method%opt .and. .not. quick_method%grad) then
+  if ( .not. quick_method%opt) then
     SAFE_CALL(getEnergy(.false.,ierr))
   endif
 


### PR DESCRIPTION
Remove computation of energy (SCF) from getGradient() function.

Separating tasks cleanly enables for instance to read results from a prior SCF calculation, then skip the SCF and compute the gradient.

This is just a quick refactor start. There is still code duplication (e.g. GPU uploads etc) in the main program and scf/grad/optimizer code paths. This should be cleaned up and made more modular.