### PR TITLE
Skip K accumulation for GPU 2e integrals if HF exchange fraction is zero

### DIFF
--- a/src/gpu/gpu_get2e_subs.h
+++ b/src/gpu/gpu_get2e_subs.h
@@ -436,6 +436,8 @@ __device__ static inline void iclass_spdf10
 #endif
                             }
 
+                            if (devSim.hyb_coeff == 0.0) continue;
+
                             // ATOMIC ADD VALUE 3
 #if defined(OSHELL)
                             temp = (III == KKK && III < JJJ && JJJ < LLL)


### PR DESCRIPTION
## Changes

### `gpu/gpu_get2e_subs.h`

Add a line in a GPU kernel function to compute J and K that skips the atomic adds that adds K when the HF exchange fraction is zero.

## Benchmarks

Benchmarks were done on morphine and taxol. See [this attached file (benchmark.tar.gz)](https://github.com/user-attachments/files/29917335/benchmark.tar.gz) for detailed benchmark information.

**Conclusion:** This change provides an approximate 1.1x speedup on consumer hardware.